### PR TITLE
fix: fastapi with docker compose

### DIFF
--- a/fastapi-postgres/Dockerfile
+++ b/fastapi-postgres/Dockerfile
@@ -1,6 +1,13 @@
 # Use the official Python image as the base image
 FROM python:3.11.5-bullseye
 
+# Install PostgreSQL client
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+	postgresql-client \
+    curl \
+    netcat-traditional
+
 # Set the working directory to /app
 WORKDIR /app
 
@@ -20,11 +27,8 @@ COPY . .
 #     POSTGRES_HOST=0.0.0.0 \
 #     POSTGRES_PORT=5432
 
-# Install PostgreSQL client
-RUN apt-get update && apt-get install -y postgresql-client
-
 # Expose port 80 for the FastAPI application
 EXPOSE 8000
 
 # Start the FastAPI application
-CMD ["uvicorn", "application.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD [ "/app/entrypoint.sh" ]

--- a/fastapi-postgres/docker-compose.yml
+++ b/fastapi-postgres/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql
     networks:
       - keploy-network
-  
+
   app:
     container_name: fastapi-app
     image: fastapi
@@ -27,3 +27,7 @@ services:
       - postgres
     networks:
       - keploy-network
+
+networks:
+  keploy-network:
+    external: true

--- a/fastapi-postgres/entrypoint.sh
+++ b/fastapi-postgres/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+until nc -z -v -w30 postgres 5432
+do
+  echo "Waiting for database connection..."
+  # wait for 5 seconds before check again
+  sleep 5
+done
+
+uvicorn application.main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
fixes #13 the issue of FastAPI not working with docker-compose to record or capture tests with keploy as the container would exit without it being present in docker-compose.

- Edited Dockerfile to build more efficiently by caching the apt installed packages before rebuilding each time