### PR TITLE
Bugfix/fastapi postgres changes

### DIFF
--- a/fastapi-postgres/application/database.py
+++ b/fastapi-postgres/application/database.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 
-SQLALCHEMY_DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/studentdb"
+SQLALCHEMY_DATABASE_URL = "postgresql://postgres:postgres@postgres:5432/studentdb"
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/fastapi-postgres/application/main.py
+++ b/fastapi-postgres/application/main.py
@@ -8,7 +8,7 @@ import asyncio
 from . import models, crud, schemas
 
 # Database setup
-SQLALCHEMY_DATABASE_URL = "postgresql://postgres:postgres@localhost:5432/studentdb"
+SQLALCHEMY_DATABASE_URL = "postgresql://postgres:postgres@postgres:5432/studentdb"
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()

--- a/fastapi-postgres/docker-compose.yml
+++ b/fastapi-postgres/docker-compose.yml
@@ -3,6 +3,7 @@ services:
 
   postgres:
     image: postgres:latest
+    container_name: postgres
     environment:
       POSTGRES_DB: studentdb
       POSTGRES_USER: postgres


### PR DESCRIPTION
Container couldn't be started without changing the local host to container name (postgres)
- Replaced to container name in main.py and database.py files.

Application couldn't be started, because container name for DB not mentioned anywhere
- added container name in a new line for docker-compose.yml file
