### PR TITLE
Fix: Remove uvloop (unsupported on Windows), add pytest, and configure .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environment
+venv/
+ENV/
+env/
+.venv/
+.ENV/
+
+# VS Code settings
+.vscode/
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Logs
+*.log
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/flask-mongo/requirements.txt
+++ b/flask-mongo/requirements.txt
@@ -37,6 +37,7 @@ typer==0.12.3
 typing_extensions==4.12.2
 urllib3==2.2.2
 uvicorn==0.30.3
-uvloop==0.19.0
+# uvloop==0.19.0 # Skipped on Windows - not supported
 watchfiles==0.22.0
 websockets==12.0
+pytest>=7.0 


### PR DESCRIPTION
###  Summary of Changes

- Removed `uvloop` from `requirements.txt` as it is not supported on Windows and is not used in the codebase.
- Added missing `pytest` dependency to `requirements.txt` since it was imported in `app.py`.
- Created a `.gitignore` file to exclude virtual environments, compiled Python files, IDE settings, logs, and system files.

###  Why These Changes Matter

These updates enhance cross-platform compatibility (especially for Windows users), ensure a proper environment setup, and adhere to best practices for Python development.

###  Verification

- Verified that `uvloop` was not imported or used in any `.py` file.
- Ensured that `pytest` is required by inspecting the imports.
- `.gitignore` follows standard Python, VS Code, and OS ignore rules.

>  Note: Code execution was not performed, but all changes were carefully verified through file inspection and setup steps.

