### PR TITLE
fix: Add fastapi-app service to docker-compose.yml.

### DIFF
--- a/fastapi-postgres/docker-compose.yml
+++ b/fastapi-postgres/docker-compose.yml
@@ -14,6 +14,13 @@ services:
       - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql
     networks:
       - keploy-network
+  fastapi-app:
+    build: .
+    command: uvicorn main:app --host 0.0.0.0 --port 8000
+    ports:
+      - "8000:8000"
+    depends_on:
+      - postgres
 
   app:
     container_name: fastapi-app


### PR DESCRIPTION
## 🛠️ Description

This PR fixes Issue #13 by adding the missing `fastapi-app` service to the `docker-compose.yml` file under the `fastapi-postgres` sample.

Previously, the FastAPI container was not defined in `docker-compose.yml`, which prevented `keploy record` from detecting the application for testing.

## 🔧 Changes Made

- Added `fastapi-app` service to `fastapi-postgres/docker-compose.yml`
- Defined build context, ports, and dependencies
- Enabled `keploy record` to work as expected with FastAPI

## ✅ How I Tested

- Ran `docker-compose up` to start both FastAPI and Postgres
- Verified FastAPI runs on port 8000
- Used `keploy record -c "docker-compose up" --container-name fastapi-app` to capture test cases successfully
- Confirmed test and mock files are generated

## 📌 Related Issue

Fixes #13

Let me know if there are additional changes or test scenarios you'd like me to add. Happy to iterate!
<img width="395" alt="Screenshot 2025-06-19 043156" src="https://github.com/user-attachments/assets/b3c1ac3a-7ce3-4313-81b1-08feb3531d6c" />
