### PR TITLE
 Fix incorrect repo link and add beginner tips to flask-redis README

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,3 @@
+## 👩‍💻 Contributors
+
+- Jamuna Devi – Keploy API Fellowship participant 🚀

--- a/flask-redis/README.md
+++ b/flask-redis/README.md
@@ -20,7 +20,7 @@ brew install redis
 If homebrew is not installed, then go to https://brew.sh/ and install it.
 
 ```bash
-git clone https://github.com/keploy/samples-typescript && cd samples-typescript/flask-redis
+git clone https://github.com/keploy/samples-python && cd samples-python/flask-redis
 
 # Install the dependencies
 pip3 install -r requirements.txt
@@ -158,3 +158,15 @@ keploy test -c 'sudo docker-compose up' --containerName "flask-web" --delay 10
 ```
 
 _Voila!! Our testcases has passed 🌟_
+
+---
+
+## 💡 Beginner Tips
+
+- 🧪 It's highly recommended to use a **virtual environment** to manage Python dependencies without conflicts.
+- 🐳 Make sure Docker is installed and running before using the Docker-based setup.
+- ⚠️ If you're on **Windows**, use **WSL** for native mode (not traditional CMD or PowerShell).
+- 🧾 Don’t forget to create the `.env` file before running the app — it's required for Redis.
+- 🧰 Not familiar with tools like Postman or curl? Try [Hoppscotch](https://hoppscotch.io) — it's beginner friendly.
+
+---


### PR DESCRIPTION
As part of the Keploy API Fellowship, I improved the README for the `flask-redis` folder by:

- Fixing the incorrect clone command (was pointing to samples-typescript)
- Adding a helpful "Beginner Tips" section to make it easier for new developers to get started

This is my first open-source contribution — looking forward to learning and contributing more 🚀
