### PR TITLE
chore: parametize debian codename

### DIFF
--- a/flask-mongo/Dockerfile
+++ b/flask-mongo/Dockerfile
@@ -1,14 +1,29 @@
-# Use the official Python image as the base image
-FROM python:3.9
+# Define an argument for the Debian version with a default value
+# This allows you to build for a specific version, e.g., bullseye, bookworm, or trixie
+ARG DEBIAN_VERSION=bookworm
 
-# Set the working directory within the container
+# Use the argument in the FROM instruction
+FROM python:3.9-slim-${DEBIAN_VERSION}
+
+# Set the working directory
 WORKDIR /app
 
-# Copy the application code into the container
+# Create a non-root user to run the application
+RUN addgroup --system appgroup && adduser --system --ingroup appgroup appuser
+
+# Copy the requirements file and install dependencies
+# This is done first to leverage Docker's layer caching
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code
 COPY . .
 
-# Install the required packages
-RUN pip3 install -r requirements.txt
+# Change ownership of the app directory to the non-root user
+RUN chown -R appuser:appgroup /app
+
+# Switch to the non-root user
+USER appuser
 
 # Expose the port that the Flask app will run on
 EXPOSE 6000

--- a/flask-mongo/Dockerfile
+++ b/flask-mongo/Dockerfile
@@ -5,6 +5,17 @@ ARG DEBIAN_VERSION=bookworm
 # Use the argument in the FROM instruction
 FROM python:3.9-slim-${DEBIAN_VERSION}
 
+# --- DNS/NSS fix (bullseye-slim often lacks these) ---
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libnss-dns libnss-files netbase ca-certificates && \
+    rm -rf /var/lib/apt/lists/*; \
+    # Ensure glibc actually consults DNS
+    if ! grep -q '^hosts:.*\bdns\b' /etc/nsswitch.conf 2>/dev/null; then \
+        echo 'hosts: files dns' > /etc/nsswitch.conf; \
+    fi
+
 # Set the working directory
 WORKDIR /app
 


### PR DESCRIPTION
This pull request updates the `Dockerfile` for the Flask-Mongo application to improve security, build flexibility, and Docker layer caching. The most important changes are grouped below:

**Security and Best Practices:**

* Added creation of a non-root user (`appuser`) and switched the container to run the application as this user instead of root, improving security.
* Changed ownership of the `/app` directory to the non-root user to ensure proper permissions.

**Build Flexibility and Efficiency:**

* Introduced a build argument `DEBIAN_VERSION` to allow specifying the Debian version for the base image, making the build more flexible for different environments.
* Switched the base image to `python:3.9-slim-${DEBIAN_VERSION}` for a smaller image footprint and compatibility with the chosen Debian version.
* Optimized dependency installation by copying `requirements.txt` and installing dependencies before copying the rest of the application code, leveraging Docker’s layer caching for faster rebuilds.