### PR TITLE
add(django-permission-cohort-postgres): minimal sample for keploy/integrations e2e lane

### DIFF
--- a/django-permission-cohort-postgres/Dockerfile
+++ b/django-permission-cohort-postgres/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /app
+
+RUN chmod +x /app/entrypoint.sh
+
+EXPOSE 8080
+
+CMD ["/app/entrypoint.sh"]

--- a/django-permission-cohort-postgres/README.md
+++ b/django-permission-cohort-postgres/README.md
@@ -1,0 +1,44 @@
+# django-permission-cohort-postgres
+
+Minimal Django + PostgreSQL sample that reproduces the `django_content_type` permission-lookup pattern. Each request to `/lookup/<app_label>/<model>/` clears Django's in-process `ContentType` cache and forces the SQL:
+
+```sql
+SELECT "django_content_type"."id",
+       "django_content_type"."app_label",
+       "django_content_type"."model"
+  FROM "django_content_type"
+ WHERE "django_content_type"."app_label" = $1
+   AND "django_content_type"."model" = $2
+ LIMIT 21
+```
+
+That query is what surfaced the postgres v3 session-fallback lifetime-gate bug in [keploy/enterprise#1952](https://github.com/keploy/enterprise/issues/1952). The sample exists so the keploy/integrations e2e lane (`.woodpecker/django-permission-cohort-postgres.yml`) can drive it end-to-end through record + replay.
+
+## Endpoints
+
+| Path | Effect |
+|---|---|
+| `GET /health/` | `{"status":"ok"}` (used as wait-for-app gate) |
+| `GET /lookup/<app_label>/<model>/` | Looks up the matching `ContentType` row, returns `{id, app_label, model}` |
+
+## Run standalone
+
+```bash
+docker compose up
+curl http://localhost:8080/health/
+curl http://localhost:8080/lookup/auth/user/
+curl http://localhost:8080/lookup/auth/group/
+```
+
+## What it intentionally does NOT have
+
+- No admin
+- No DRF / JWT / token auth — the bug shape doesn't need them
+- No static files, no templates, no signal handlers, no celery
+- No migrations beyond Django's stock contenttypes/auth tables — those are exactly what the lookup hits
+
+The sample is small on purpose so the failing query is the only DB traffic that matters at replay time.
+
+## Why CONN_MAX_AGE=0
+
+Default `CONN_MAX_AGE=0` (a fresh connection per request) makes Django redo any first-connect work on every request. That keeps the per-request DB call sequence deterministic across record/replay — important for a regression sample.

--- a/django-permission-cohort-postgres/docker-compose.yml
+++ b/django-permission-cohort-postgres/docker-compose.yml
@@ -20,7 +20,16 @@ services:
       # HTTP test windows — the precondition for the session-fallback
       # path the lifetime-gate fix unblocks.
       BACKGROUND_LOOKUPS: "1"
-      BACKGROUND_LOOKUPS_INTERVAL_S: "3"
+      # Fire the background thread every 0.3s. The keploy `test` driver
+      # replays all captured HTTP cases in ~1 second, so a 3s cadence
+      # means at most one thread-fire lands during the replay-window
+      # phase — and the dispatcher routes most of them to
+      # SessionTransactional directly (bypassing the PerTest →
+      # SessionFallback path the lifetime-gate fix actually unblocks).
+      # 0.3s gives ~3-5 thread-fires per replay run that fall *inside*
+      # an HTTP test window, which is the precondition for hitting
+      # the SessionFallback gate.
+      BACKGROUND_LOOKUPS_INTERVAL_S: "0.3"
     depends_on:
       db:
         condition: service_healthy

--- a/django-permission-cohort-postgres/docker-compose.yml
+++ b/django-permission-cohort-postgres/docker-compose.yml
@@ -1,38 +1,4 @@
 services:
-  # One-shot migrator. Runs Django's `migrate` (which fires the
-  # `post_migrate` signal that bulk-inserts ContentType rows) against
-  # the db and exits. The api service waits for it to complete cleanly
-  # before starting gunicorn.
-  #
-  # Why this is a separate container rather than inline in the api
-  # entrypoint: when this stack runs under keploy record/replay, keploy
-  # only intercepts traffic for the named application container (api).
-  # Migrations fired from a sibling container bypass the keploy proxy
-  # entirely, so the migration SQL never lands in mocks.yaml. That
-  # matters because Django's `post_migrate` ContentType bulk_create
-  # batches all installed-apps' ContentType rows into a single simple-
-  # query INSERT whose row-tuple ordering is sensitive to model-
-  # registration timing — capturing it makes recordings non-replayable
-  # if any boot-time ordering shifts between record and replay.
-  migrator:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    container_name: djpcohort_migrator
-    networks:
-      - djnet
-    environment:
-      DB_HOST: db
-      DB_PORT: 5432
-      DB_USER: djpcohort
-      DB_PASSWORD: djpcohort
-      DB_NAME: djpcohort
-    command: ["python", "/app/manage.py", "migrate", "--noinput"]
-    depends_on:
-      db:
-        condition: service_healthy
-    restart: "no"
-
   api:
     build:
       context: .
@@ -67,8 +33,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      migrator:
-        condition: service_completed_successfully
     restart: on-failure
 
   db:

--- a/django-permission-cohort-postgres/docker-compose.yml
+++ b/django-permission-cohort-postgres/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: api
+    ports:
+      - "8080:8080"
+    networks:
+      - djnet
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: djpcohort
+      DB_PASSWORD: djpcohort
+      DB_NAME: djpcohort
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: on-failure
+
+  db:
+    image: postgres:16-alpine
+    container_name: djpcohort_db
+    networks:
+      - djnet
+    environment:
+      POSTGRES_USER: djpcohort
+      POSTGRES_PASSWORD: djpcohort
+      POSTGRES_DB: djpcohort
+    ports:
+      - "127.0.0.1:55437:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U djpcohort -d djpcohort"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+
+networks:
+  djnet:

--- a/django-permission-cohort-postgres/docker-compose.yml
+++ b/django-permission-cohort-postgres/docker-compose.yml
@@ -14,6 +14,17 @@ services:
       DB_USER: djpcohort
       DB_PASSWORD: djpcohort
       DB_NAME: djpcohort
+      # Pin Python's per-process hash seed so set/dict iteration order
+      # is identical across record and replay runs. Django's
+      # `post_migrate` ContentType bulk_create populates VALUES rows
+      # from a model collection that, in some Django versions, is
+      # iterated in a hash-seed-dependent order; without a fixed seed
+      # the recorder captures one row order at record time and the
+      # live driver fires a different row order at replay time. The
+      # SQL hashes match (same skeleton) but the inline value tuples
+      # diverge — exactly the `bind values diverged from every
+      # recorded invocation` failure shape the build-build cell hit.
+      PYTHONHASHSEED: "0"
       # Spawn the background ContentType-lookup thread (see
       # myproj/apps.py). The keploy/integrations e2e lane needs this
       # to record `SELECT django_content_type` invocations *between*

--- a/django-permission-cohort-postgres/docker-compose.yml
+++ b/django-permission-cohort-postgres/docker-compose.yml
@@ -14,6 +14,13 @@ services:
       DB_USER: djpcohort
       DB_PASSWORD: djpcohort
       DB_NAME: djpcohort
+      # Spawn the background ContentType-lookup thread (see
+      # myproj/apps.py). The keploy/integrations e2e lane needs this
+      # to record `SELECT django_content_type` invocations *between*
+      # HTTP test windows — the precondition for the session-fallback
+      # path the lifetime-gate fix unblocks.
+      BACKGROUND_LOOKUPS: "1"
+      BACKGROUND_LOOKUPS_INTERVAL_S: "3"
     depends_on:
       db:
         condition: service_healthy

--- a/django-permission-cohort-postgres/docker-compose.yml
+++ b/django-permission-cohort-postgres/docker-compose.yml
@@ -14,33 +14,10 @@ services:
       DB_USER: djpcohort
       DB_PASSWORD: djpcohort
       DB_NAME: djpcohort
-      # Pin Python's per-process hash seed so set/dict iteration order
-      # is identical across record and replay runs. Django's
-      # `post_migrate` ContentType bulk_create populates VALUES rows
-      # from a model collection that, in some Django versions, is
-      # iterated in a hash-seed-dependent order; without a fixed seed
-      # the recorder captures one row order at record time and the
-      # live driver fires a different row order at replay time. The
-      # SQL hashes match (same skeleton) but the inline value tuples
-      # diverge — exactly the `bind values diverged from every
-      # recorded invocation` failure shape the build-build cell hit.
+      # Defence-in-depth: pin Python's per-process hash seed so any
+      # set/dict iteration anywhere in the Django stack is stable
+      # across record and replay runs.
       PYTHONHASHSEED: "0"
-      # Spawn the background ContentType-lookup thread (see
-      # myproj/apps.py). The keploy/integrations e2e lane needs this
-      # to record `SELECT django_content_type` invocations *between*
-      # HTTP test windows — the precondition for the session-fallback
-      # path the lifetime-gate fix unblocks.
-      BACKGROUND_LOOKUPS: "1"
-      # Fire the background thread every 0.3s. The keploy `test` driver
-      # replays all captured HTTP cases in ~1 second, so a 3s cadence
-      # means at most one thread-fire lands during the replay-window
-      # phase — and the dispatcher routes most of them to
-      # SessionTransactional directly (bypassing the PerTest →
-      # SessionFallback path the lifetime-gate fix actually unblocks).
-      # 0.3s gives ~3-5 thread-fires per replay run that fall *inside*
-      # an HTTP test window, which is the precondition for hitting
-      # the SessionFallback gate.
-      BACKGROUND_LOOKUPS_INTERVAL_S: "0.3"
     depends_on:
       db:
         condition: service_healthy

--- a/django-permission-cohort-postgres/docker-compose.yml
+++ b/django-permission-cohort-postgres/docker-compose.yml
@@ -1,4 +1,38 @@
 services:
+  # One-shot migrator. Runs Django's `migrate` (which fires the
+  # `post_migrate` signal that bulk-inserts ContentType rows) against
+  # the db and exits. The api service waits for it to complete cleanly
+  # before starting gunicorn.
+  #
+  # Why this is a separate container rather than inline in the api
+  # entrypoint: when this stack runs under keploy record/replay, keploy
+  # only intercepts traffic for the named application container (api).
+  # Migrations fired from a sibling container bypass the keploy proxy
+  # entirely, so the migration SQL never lands in mocks.yaml. That
+  # matters because Django's `post_migrate` ContentType bulk_create
+  # batches all installed-apps' ContentType rows into a single simple-
+  # query INSERT whose row-tuple ordering is sensitive to model-
+  # registration timing — capturing it makes recordings non-replayable
+  # if any boot-time ordering shifts between record and replay.
+  migrator:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: djpcohort_migrator
+    networks:
+      - djnet
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: djpcohort
+      DB_PASSWORD: djpcohort
+      DB_NAME: djpcohort
+    command: ["python", "/app/manage.py", "migrate", "--noinput"]
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: "no"
+
   api:
     build:
       context: .
@@ -33,6 +67,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      migrator:
+        condition: service_completed_successfully
     restart: on-failure
 
   db:

--- a/django-permission-cohort-postgres/entrypoint.sh
+++ b/django-permission-cohort-postgres/entrypoint.sh
@@ -1,16 +1,15 @@
 #!/usr/bin/env bash
-# entrypoint.sh — run Django migrations once, then start gunicorn.
+# entrypoint.sh — start gunicorn.
 #
-# The migrations populate django_content_type and the auth_*
-# permission tables; without this the /lookup/ endpoint would have
-# nothing to find. We migrate inline at container start (rather than
-# in a separate init container) so the recorder captures both the
-# migration sequence and the runtime queries on the same connection
-# pool — keeps the record/replay traffic shape minimal.
+# Migrations are applied by a sibling `migrator` service in
+# docker-compose.yml that runs to completion before this container
+# starts. Keeping the migration step out of the api container is what
+# lets the keploy/integrations record-replay lane stay deterministic:
+# Django's `post_migrate` signal bulk-inserts ContentType rows in a
+# single simple-query INSERT whose row ordering depends on model-
+# registration timing, and capturing that under the keploy proxy
+# would make recordings non-replayable across runs.
 set -Eeuo pipefail
-
-echo "[entrypoint] running migrations..."
-python /app/manage.py migrate --noinput
 
 echo "[entrypoint] starting gunicorn on :8080..."
 # --timeout 300: matcher round-trips through the keploy proxy can spike

--- a/django-permission-cohort-postgres/entrypoint.sh
+++ b/django-permission-cohort-postgres/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# entrypoint.sh — run Django migrations once, then start gunicorn.
+#
+# The migrations populate django_content_type and the auth_*
+# permission tables; without this the /lookup/ endpoint would have
+# nothing to find. We migrate inline at container start (rather than
+# in a separate init container) so the recorder captures both the
+# migration sequence and the runtime queries on the same connection
+# pool — keeps the record/replay traffic shape minimal.
+set -Eeuo pipefail
+
+echo "[entrypoint] running migrations..."
+python /app/manage.py migrate --noinput
+
+echo "[entrypoint] starting gunicorn on :8080..."
+exec gunicorn \
+  --bind 0.0.0.0:8080 \
+  --workers 2 \
+  --threads 1 \
+  --timeout 60 \
+  --access-logfile - \
+  --error-logfile - \
+  --capture-output \
+  --log-level info \
+  myproj.wsgi:application

--- a/django-permission-cohort-postgres/entrypoint.sh
+++ b/django-permission-cohort-postgres/entrypoint.sh
@@ -13,11 +13,18 @@ echo "[entrypoint] running migrations..."
 python /app/manage.py migrate --noinput
 
 echo "[entrypoint] starting gunicorn on :8080..."
+# --timeout 300: matcher round-trips through the keploy proxy can spike
+#   under CI load; gunicorn's default 30s SIGKILLs the worker mid-request
+#   and the test that landed on that worker times out client-side. 300s
+#   gives the proxy comfortable headroom.
+# --workers 4 / --threads 2: enough concurrency that a single slow
+#   matcher response doesn't queue subsequent requests behind it.
 exec gunicorn \
   --bind 0.0.0.0:8080 \
-  --workers 2 \
-  --threads 1 \
-  --timeout 60 \
+  --workers 4 \
+  --threads 2 \
+  --timeout 300 \
+  --graceful-timeout 30 \
   --access-logfile - \
   --error-logfile - \
   --capture-output \

--- a/django-permission-cohort-postgres/entrypoint.sh
+++ b/django-permission-cohort-postgres/entrypoint.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
-# entrypoint.sh — start gunicorn.
+# entrypoint.sh — run Django migrations once, then start gunicorn.
 #
-# Migrations are applied by a sibling `migrator` service in
-# docker-compose.yml that runs to completion before this container
-# starts. Keeping the migration step out of the api container is what
-# lets the keploy/integrations record-replay lane stay deterministic:
-# Django's `post_migrate` signal bulk-inserts ContentType rows in a
-# single simple-query INSERT whose row ordering depends on model-
-# registration timing, and capturing that under the keploy proxy
-# would make recordings non-replayable across runs.
+# The migrations populate django_content_type and the auth_*
+# permission tables; without this the /lookup/ endpoint would have
+# nothing to find. We migrate inline at container start (rather than
+# in a separate init container) so the recorder captures both the
+# migration sequence and the runtime queries on the same connection
+# pool — keeps the record/replay traffic shape minimal.
 set -Eeuo pipefail
+
+echo "[entrypoint] running migrations..."
+python /app/manage.py migrate --noinput
 
 echo "[entrypoint] starting gunicorn on :8080..."
 # --timeout 300: matcher round-trips through the keploy proxy can spike

--- a/django-permission-cohort-postgres/manage.py
+++ b/django-permission-cohort-postgres/manage.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+import os
+import sys
+
+
+def main():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "myproj.settings")
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/django-permission-cohort-postgres/myproj/apps.py
+++ b/django-permission-cohort-postgres/myproj/apps.py
@@ -1,0 +1,91 @@
+"""
+AppConfig that spawns a background ContentType-lookup thread inside
+each gunicorn worker.
+
+Why this exists
+---------------
+The keploy/integrations django-permission-cohort-postgres lane is a
+falsifying e2e lane for the postgres-v3 session-fallback lifetime-gate
+fix (keploy/enterprise#1952). To produce the bug shape end-to-end,
+the recording must capture some `SELECT django_content_type`
+invocations whose request-timestamp falls *between* the surrounding
+HTTP test windows. Those out-of-window captures are routed by the
+keploy agent's lax-promotion path
+(FilterPerTestAndLaxPromotedTierAware in keploy/keploy:pkg/util.go)
+into the session pool — preserving their on-disk
+`lifetime: perTest` tag. Replay-side, the live request that fires
+during a test whose perTest cohort is empty for that SQL hash falls
+through to the session-fallback path; pre-fix the lifetime gate
+silently rejected the lax-promoted invocation, post-fix the
+mutation-aware gate accepts it.
+
+The lane's HTTP-driven exerciser alone can't produce that shape: any
+query fired inside an HTTP request lands inside that test's window
+and ends up in its perTest cohort, never out-of-window. We need
+DB activity that fires *outside* the HTTP request path.
+
+This thread provides that: each gunicorn worker spawns one daemon
+thread that periodically clears Django's in-process ContentType
+cache, runs a fresh `ContentType.objects.get(...)` (which forces the
+SQL the bug surfaces on), and sleeps. The cadence (default 3s) is
+slow enough not to swamp the worker pool but fast enough that the
+exerciser's 6s inter-round pause captures multiple thread-fired
+queries between HTTP test windows.
+
+The thread is gated behind the BACKGROUND_LOOKUPS env var so the
+sample stays usable as a plain Django app for ad-hoc local testing.
+The CI lane sets BACKGROUND_LOOKUPS=1.
+"""
+import logging
+import os
+import threading
+import time
+
+from django.apps import AppConfig
+
+logger = logging.getLogger(__name__)
+
+
+class MyProjConfig(AppConfig):
+    name = "myproj"
+    default = True
+
+    def ready(self):
+        # `ready()` runs at most once per worker (Django guarantees idempotency
+        # within a process), so the thread spawn is safe here. Daemon=True
+        # ensures the thread doesn't block worker shutdown.
+        if os.environ.get("BACKGROUND_LOOKUPS", "0") != "1":
+            return
+        # Lookup-target cycle — different (app_label, model) pairs to widen
+        # the hash spectrum so the recording's session-fallback cohort isn't
+        # a single-shape singleton. All target the same SQL hash (different
+        # binds), which is the shape the lifetime-gate fix unblocks.
+        targets = [
+            ("auth", "user"),
+            ("auth", "group"),
+            ("auth", "permission"),
+            ("contenttypes", "contenttype"),
+        ]
+        interval_s = float(os.environ.get("BACKGROUND_LOOKUPS_INTERVAL_S", "3"))
+
+        def loop():
+            # Lazy import — apps aren't all loaded at module-import time.
+            from django.contrib.contenttypes.models import ContentType
+
+            i = 0
+            while True:
+                try:
+                    time.sleep(interval_s)
+                    app_label, model = targets[i % len(targets)]
+                    ContentType.objects.clear_cache()
+                    ContentType.objects.get(app_label=app_label, model=model)
+                    i += 1
+                except Exception as exc:  # noqa: BLE001 — keep the thread alive
+                    logger.warning("background lookup failed: %s", exc)
+
+        threading.Thread(target=loop, daemon=True, name="bg-content-type-lookups").start()
+        logger.info(
+            "background ContentType-lookup thread started (interval=%ss, targets=%s)",
+            interval_s,
+            len(targets),
+        )

--- a/django-permission-cohort-postgres/myproj/settings.py
+++ b/django-permission-cohort-postgres/myproj/settings.py
@@ -24,6 +24,13 @@ INSTALLED_APPS = [
     # AND model=$2, the exact query the lifetime-gate bug surfaces on.
     "django.contrib.contenttypes",
     "django.contrib.auth",
+    # myproj.apps.MyProjConfig spawns a background ContentType-lookup
+    # thread when BACKGROUND_LOOKUPS=1 — the keploy/integrations e2e
+    # lane uses this to drive DB activity *outside* the HTTP request
+    # path, so the recording captures session-pool-bound invocations
+    # the lifetime-gate fix unblocks. Off by default; ad-hoc local
+    # use of this sample doesn't need it.
+    "myproj.apps.MyProjConfig",
 ]
 
 MIDDLEWARE = []

--- a/django-permission-cohort-postgres/myproj/settings.py
+++ b/django-permission-cohort-postgres/myproj/settings.py
@@ -46,6 +46,23 @@ DATABASES = {
         # which makes Django redo any first-connect work each time. We
         # keep that default so the per-request DB call sequence is
         # deterministic across record/replay.
+        "OPTIONS": {
+            # Skip libpq's SSLRequest preamble. The compose stack runs
+            # cleartext postgres; without sslmode=disable, psycopg2
+            # sends the SSLRequest byte sequence and waits for an 'S'
+            # or 'N' response. Postgres replies with 'R' (auth
+            # request, skipping SSL negotiation entirely), keploy's
+            # v3 recorder/proxy logs this as "unexpected SSL
+            # response", and on the *first* fresh connection at
+            # replay time the proxy stalls waiting for an SSL
+            # handshake the server isn't going to complete — every
+            # first request to a new endpoint then hangs until the
+            # client-side timeout fires. Setting sslmode=disable
+            # makes psycopg2 skip the preamble entirely so every
+            # request flows on the clean cleartext path the proxy
+            # already handles.
+            "sslmode": "disable",
+        },
     }
 }
 

--- a/django-permission-cohort-postgres/myproj/settings.py
+++ b/django-permission-cohort-postgres/myproj/settings.py
@@ -1,0 +1,66 @@
+"""
+Minimal Django settings for the django-permission-cohort-postgres
+e2e lane (keploy/integrations).
+
+The app exists only to exercise the ContentType permission-lookup
+shape that surfaced the postgres-v3 lifetime-gate bug fixed in this
+PR. It is intentionally as small as possible: no admin, no static
+files, no DRF, no migrations beyond the contenttypes/auth defaults
+Django ships out of the box. Anything that doesn't help reproduce
+the recorder→lax-promotion→session-fallback path is omitted.
+"""
+import os
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+SECRET_KEY = "ci-only-not-secret"
+DEBUG = False
+ALLOWED_HOSTS = ["*"]
+
+INSTALLED_APPS = [
+    # contenttypes is the load-bearing piece — every request to the
+    # /lookup/ view fires SELECT django_content_type WHERE app_label=$1
+    # AND model=$2, the exact query the lifetime-gate bug surfaces on.
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+]
+
+MIDDLEWARE = []
+
+ROOT_URLCONF = "myproj.urls"
+
+TEMPLATES = []
+
+WSGI_APPLICATION = "myproj.wsgi.application"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.environ.get("DB_NAME", "djpcohort"),
+        "USER": os.environ.get("DB_USER", "djpcohort"),
+        "PASSWORD": os.environ.get("DB_PASSWORD", "djpcohort"),
+        "HOST": os.environ.get("DB_HOST", "db"),
+        "PORT": os.environ.get("DB_PORT", "5432"),
+        # CONN_MAX_AGE=0 (default) means a fresh connection per request,
+        # which makes Django redo any first-connect work each time. We
+        # keep that default so the per-request DB call sequence is
+        # deterministic across record/replay.
+    }
+}
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+USE_TZ = True
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {"class": "logging.StreamHandler"},
+    },
+    "root": {"handlers": ["console"], "level": "INFO"},
+    "loggers": {
+        "django.db.backends": {"handlers": ["console"], "level": "INFO"},
+    },
+}

--- a/django-permission-cohort-postgres/myproj/urls.py
+++ b/django-permission-cohort-postgres/myproj/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path("health/", views.health),
+    path("lookup/<str:app_label>/<str:model>/", views.lookup),
+]

--- a/django-permission-cohort-postgres/myproj/views.py
+++ b/django-permission-cohort-postgres/myproj/views.py
@@ -4,9 +4,7 @@ Two endpoints, both deliberately minimal:
   GET /health/                   -> 200 with {"status":"ok"}
   GET /lookup/<app_label>/<model>/  -> 200 with the ContentType row
 
-The lookup view is the load-bearing one. It calls
-ContentType.objects.clear_cache() before each lookup so the in-process
-cache never short-circuits the query. Every request therefore fires:
+The lookup view fires the load-bearing query:
 
     SELECT "django_content_type"."id",
            "django_content_type"."app_label",
@@ -16,21 +14,101 @@ cache never short-circuits the query. Every request therefore fires:
             AND "django_content_type"."model" = $2)
      LIMIT 21
 
-That query is `class: APP` per pgmatch.Classify (a SELECT from a
-user-schema table, not pg_catalog), so DeriveLifetime tags every
-captured invocation `LifetimePerTest`. With the lifetime gate at
-pickSessionFallback (pre-fix), once a per-test cohort is empty for the
-SQL hash but the agent has lax-promoted the same hash into the
-session pool, the matcher misses with `candidates: 0` and
-`sessionFallbackCandidates: N>0`. That's the doccano-shape failure
-this lane regresses against.
+That query is `class: APP` per pgmatch.Classify, so DeriveLifetime
+tags every captured invocation `LifetimePerTest`. With the lifetime
+gate at pickSessionFallback (pre-fix), once a per-test cohort is
+empty for the SQL hash but the agent has lax-promoted the same hash
+into the session pool, the matcher misses with `candidates: 0` and
+`sessionFallbackCandidates: N>0`.
+
+The view ALSO spawns a delayed side-query thread (see
+_fire_delayed_side_query) on every request. This is the deterministic
+mechanism that surfaces the lifetime-gate bug shape end-to-end —
+without it the lane is regression coverage but not falsifying.
 """
+import threading
+import time
+
 from django.contrib.contenttypes.models import ContentType
+from django.db import close_old_connections
 from django.http import JsonResponse, HttpResponseNotFound
+
+# Fixed bind values for the side query. Deliberately one of the
+# (app_label, model) pairs the exerciser also calls directly via
+# /lookup/, so the response body is well-known and the recorded mock
+# is stable. The exerciser fires /lookup/auth/user/ as one of its
+# round members, which means at record time there's at least one
+# perTest capture of this SQL+bind in some test's window — but the
+# delayed-fire copies populated by every other request land between
+# HTTP test windows, where the agent's lax-promotion path routes
+# them into the session pool with their LifetimePerTest tag intact.
+SIDE_QUERY_APP_LABEL = "auth"
+SIDE_QUERY_MODEL = "user"
 
 
 def health(_request):
     return JsonResponse({"status": "ok"})
+
+
+def _fire_delayed_side_query():
+    """
+    Fire `SELECT django_content_type WHERE app_label='auth' AND
+    model='user'` 100 ms after the parent request's response is sent,
+    on a fresh DB connection (daemon thread → Django gives us a new
+    thread-local connection).
+
+    Why 100 ms, why fixed binds, why daemon thread:
+    --------------------------------------------------------------
+    The lifetime-gate bug surfaces only when, at replay time, a live
+    DB call lands *inside an active HTTP test window* for a SQL hash
+    whose perTest cohort is empty for that bind, *and* the session
+    pool has a lax-promoted PerTest invocation matching the bind.
+
+    Engineering this asymmetry deterministically requires that the
+    same code path produces a different test-window attribution at
+    record vs. replay. That's exactly what a fixed-delay
+    post-response thread does:
+
+      AT RECORD (exerciser fires HTTP requests ~1 s apart):
+        the 100 ms post-response delay puts the side query's
+        timestamp comfortably between test N and test N+1's
+        windows. Captured invocation lands in the session pool
+        with its LifetimePerTest tag preserved (lax-promotion).
+
+      AT REPLAY (keploy `test` compresses pacing to ~tens of ms):
+        the same 100 ms delay puts the side query's timestamp
+        *inside* a later test's window. That test's perTest
+        cohort holds a capture for *its own* HTTP-driven bind,
+        not (auth, user) — so for this hash+bind the cohort is
+        empty, the dispatcher routes through PerTest →
+        SessionFallback, and the matcher's gate is consulted.
+
+    Pre-fix matcher: lifetime-tag gate rejects every PerTest-tagged
+    candidate in the session pool → `transactional: no invocation
+    matched` ERROR → check_for_errors fails the lane.
+
+    Post-fix matcher: mutation-eligibility gate accepts non-mutating
+    shape-equal candidates regardless of lifetime → serves the
+    recorded response → green.
+
+    Daemon thread because gunicorn shouldn't wait on it during
+    worker shutdown; close_old_connections to keep Django's
+    thread-local connection registry clean.
+    """
+    time.sleep(0.1)
+    try:
+        close_old_connections()
+        ContentType.objects.get(
+            app_label=SIDE_QUERY_APP_LABEL, model=SIDE_QUERY_MODEL
+        )
+    except Exception:
+        # Replay-time mock-miss raises here; the parent response is
+        # already on the wire so we can't surface it to the client.
+        # The matcher logs the miss as an ERROR which the lane's
+        # check_for_errors assertion picks up.
+        pass
+    finally:
+        close_old_connections()
 
 
 def lookup(_request, app_label, model):
@@ -45,6 +123,9 @@ def lookup(_request, app_label, model):
             JsonResponse({"error": "not found"}).content,
             content_type="application/json",
         )
+    # Kick off the delayed side query before returning. See
+    # _fire_delayed_side_query for the timing rationale.
+    threading.Thread(target=_fire_delayed_side_query, daemon=True).start()
     return JsonResponse(
         {"id": ct.id, "app_label": ct.app_label, "model": ct.model}
     )

--- a/django-permission-cohort-postgres/myproj/views.py
+++ b/django-permission-cohort-postgres/myproj/views.py
@@ -1,0 +1,50 @@
+"""
+Two endpoints, both deliberately minimal:
+
+  GET /health/                   -> 200 with {"status":"ok"}
+  GET /lookup/<app_label>/<model>/  -> 200 with the ContentType row
+
+The lookup view is the load-bearing one. It calls
+ContentType.objects.clear_cache() before each lookup so the in-process
+cache never short-circuits the query. Every request therefore fires:
+
+    SELECT "django_content_type"."id",
+           "django_content_type"."app_label",
+           "django_content_type"."model"
+      FROM "django_content_type"
+     WHERE ("django_content_type"."app_label" = $1
+            AND "django_content_type"."model" = $2)
+     LIMIT 21
+
+That query is `class: APP` per pgmatch.Classify (a SELECT from a
+user-schema table, not pg_catalog), so DeriveLifetime tags every
+captured invocation `LifetimePerTest`. With the lifetime gate at
+pickSessionFallback (pre-fix), once a per-test cohort is empty for the
+SQL hash but the agent has lax-promoted the same hash into the
+session pool, the matcher misses with `candidates: 0` and
+`sessionFallbackCandidates: N>0`. That's the doccano-shape failure
+this lane regresses against.
+"""
+from django.contrib.contenttypes.models import ContentType
+from django.http import JsonResponse, HttpResponseNotFound
+
+
+def health(_request):
+    return JsonResponse({"status": "ok"})
+
+
+def lookup(_request, app_label, model):
+    # Clear the in-process ContentType cache so each call is forced to
+    # hit the DB. Without this, only the very first call per worker
+    # would emit the SQL we want under the recorder.
+    ContentType.objects.clear_cache()
+    try:
+        ct = ContentType.objects.get(app_label=app_label, model=model)
+    except ContentType.DoesNotExist:
+        return HttpResponseNotFound(
+            JsonResponse({"error": "not found"}).content,
+            content_type="application/json",
+        )
+    return JsonResponse(
+        {"id": ct.id, "app_label": ct.app_label, "model": ct.model}
+    )

--- a/django-permission-cohort-postgres/myproj/wsgi.py
+++ b/django-permission-cohort-postgres/myproj/wsgi.py
@@ -1,0 +1,7 @@
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "myproj.settings")
+
+application = get_wsgi_application()

--- a/django-permission-cohort-postgres/requirements.txt
+++ b/django-permission-cohort-postgres/requirements.txt
@@ -1,0 +1,3 @@
+Django==4.2.16
+gunicorn==21.2.0
+psycopg2-binary==2.9.9


### PR DESCRIPTION
# add(django-permission-cohort-postgres): minimal sample for keploy/integrations e2e lane

## TL;DR

Adds a tiny Django sample (`django-permission-cohort-postgres/`) that fires `SELECT django_content_type WHERE app_label=$1 AND model=$2` on every request. The keploy/integrations e2e lane in [keploy/integrations#167](https://github.com/keploy/integrations/pull/167) clones this sample to regress the postgres-v3 session-fallback lifetime-gate fix that surfaced as the doccano CI failure ([keploy/enterprise#1952](https://github.com/keploy/enterprise/issues/1952)).

## What the sample does

Two endpoints, both deliberately minimal:

| Path | Effect |
|---|---|
| `GET /health/` | `{"status":"ok"}` — used as wait-for-app gate |
| `GET /lookup/<app_label>/<model>/` | Calls `ContentType.objects.clear_cache()` then `ContentType.objects.get(app_label=..., model=...)` and returns the row |

`clear_cache()` before the lookup forces every request to actually hit the database, so the SQL — `SELECT django_content_type WHERE app_label=$1 AND model=$2 LIMIT 21` — fires on every call. That query is what `pgmatch.Classify` tags `class: APP`, which `DeriveLifetime` then maps to `LifetimePerTest`. That tagging is the precondition for the bug the integrations PR fixes.

## What's deliberately NOT in the sample

- No admin
- No DRF / token / session auth
- No static files, no templates, no signal handlers, no celery
- No migrations beyond Django's stock contenttypes / auth tables (those are exactly what the lookup hits)
- `CONN_MAX_AGE=0` (default) — fresh connection per request, so the per-request DB call sequence is deterministic across record and replay

The sample is small on purpose so that the failing query is the only DB traffic that matters at replay time. Anything bigger would dilute the regression target.

## How to run it standalone

```bash
docker compose up
curl http://localhost:8080/health/                            # → {"status":"ok"}
curl http://localhost:8080/lookup/auth/user/                  # → {"id":1,"app_label":"auth","model":"user"}
curl http://localhost:8080/lookup/contenttypes/contenttype/   # → {"id":...,"app_label":"contenttypes","model":"contenttype"}
```

## How keploy/integrations consumes it

The integrations lane (`keploy/integrations:.woodpecker/django-permission-cohort-postgres.yml`) has a `checkout-samples` step that runs:

```bash
git clone --depth 1 --branch add/django-permission-cohort-postgres \
  https://github.com/keploy/samples-python.git samples-python
```

The `--branch` pin will be dropped in a follow-up commit on the integrations branch once this PR merges to main.

The lane's driver script (`keploy/integrations:.ci/scripts/python/django-permission-cohort-postgres/docker.sh`) reads `SAMPLE_SRC_DIR=$WORKSPACE/samples-python/django-permission-cohort-postgres`, copies the sample into a per-run staging dir, overlays the agent-side `Dockerfile.v3agent` + `exerciser.sh` on top, and runs `keploy record` + `keploy test` across the three-binary matrix (`record-build-replay-build` / `record-latest-replay-build` / `record-build-replay-latest`).

## Why a new sample rather than reusing `django-postgres/`

`django-postgres/` is a CRUD-shaped user-data app that exercises Django's ORM but doesn't naturally hit `django_content_type` (no permission framework, no generic relations, no admin in its request path). The bug being regressed is specifically about the `ContentType` lookup pattern — same shape as the doccano failure that motivated it — so the sample is purpose-built for that. Adding it as a sibling rather than re-fitting `django-postgres/` keeps both samples narrowly-scoped and avoids regressing whatever `django-postgres/` is currently used for.

## Test plan

- [ ] Standalone `docker compose up` boots cleanly and responds 200 to `/health/` and `/lookup/auth/user/`
- [ ] keploy/integrations#167 lane (depends on this PR's branch) goes green for the `record-build-replay-build` cell
- [ ] `record-build-replay-latest` cell stays red until the integrations fix releases downstream — that asymmetry is the bug-existence signal, called out in the lane's `.yml` header comment

## References

- [keploy/integrations#167](https://github.com/keploy/integrations/pull/167) — the integrations PR that consumes this sample
- [keploy/enterprise#1952](https://github.com/keploy/enterprise/issues/1952) — RCA of the bug being regressed
- [keploy/enterprise#1889](https://github.com/keploy/enterprise/pull/1889) — original failing pipeline
