### PR TITLE
feat(doccano-django): keploy compat lane sample + Python line coverage gate

### DIFF
--- a/.github/workflows/doccano-django.yml
+++ b/.github/workflows/doccano-django.yml
@@ -175,8 +175,8 @@ jobs:
           if python3 -c "import sys; sys.exit(0 if (${RELEASE} - ${BUILD}) > ${THRESHOLD} else 1)"; then
             echo "::error::doccano-django coverage dropped from ${RELEASE}% → ${BUILD}% (-${drop}pp), exceeding the ${THRESHOLD}pp threshold."
             echo "Suggested actions:"
-            echo "  * Add curl(s) to flow.sh::doccano_record_traffic that exercise the routes you changed/touched."
-            echo "  * If the route(s) was intentionally retired, drop it from doccano-django/flow.sh::doccano_list_routes' SCOPE_PREFIXES too so it's removed from the denominator."
+            echo "  * Add curl(s) to flow.sh::doccano_record_traffic that exercise the new code paths."
+            echo "  * Or extend the .coveragerc 'omit' list if the new module is not part of the runtime backend (migrations, management commands, tests)."
             exit 1
           fi
           echo "OK — coverage delta within ${THRESHOLD}pp threshold."
@@ -196,4 +196,4 @@ jobs:
 
             Threshold: PR may not drop coverage by more than **${{ env.COVERAGE_THRESHOLD }}pp**. Override per-repo via the `DOCCANO_COVERAGE_THRESHOLD` actions variable.
 
-            Coverage measures the API surface (`/v1/projects/*` + `/v1/me` + `/v1/users` + `/v1/health` + `/v1/auth`) that `flow.sh::doccano_record_traffic` actually exercises against the running backend's URL resolver. Reports are attached as artifacts on each job ("coverage-build" / "coverage-release").
+            Coverage is **Python line coverage** (coverage.py 7.6.1) of the doccano backend code — the bytes that `flow.sh::doccano_record_traffic` actually executes. Instrumentation lives in a separate `Dockerfile.coverage` + `docker-compose.coverage.yml` overlay; the base `docker-compose.yml` consumed by keploy/integrations and keploy/enterprise CI lanes runs uninstrumented and pays zero coverage cost. Per-file reports are attached as artifacts on each job (`coverage-build` / `coverage-release`).

--- a/.github/workflows/doccano-django.yml
+++ b/.github/workflows/doccano-django.yml
@@ -1,0 +1,172 @@
+# doccano-django sample CI — keploy-independent end-to-end smoke +
+# coverage gate.
+#
+# Triggers ONLY on changes under doccano-django/ (or this workflow
+# file). Other samples in this repo have their own orthogonal CI;
+# gating the whole repo on every doccano change would slow them
+# all down for no benefit.
+#
+# What it gates:
+#   * `release-coverage` — checks out the PR's base branch (main)
+#     and runs the sample end-to-end: docker compose up, bootstrap
+#     admin token, drive flow.sh record-traffic with the per-call
+#     audit log enabled, capture the route-coverage percentage from
+#     `flow.sh coverage`. This is the baseline.
+#   * `build-coverage` — same end-to-end against the PR's HEAD ref.
+#   * `coverage-gate` — fails the PR if `build`'s coverage drops
+#     more than COVERAGE_THRESHOLD percentage points below
+#     `release`. Default threshold is 1.0pp; override via repo
+#     variable `DOCCANO_COVERAGE_THRESHOLD` for a tighter or
+#     looser bar.
+#
+# On push to main, only `build-coverage` runs (no baseline to
+# compare against — main IS the baseline).
+#
+# Standards-aligned choices:
+#   * `paths:` filter on both push and pull_request triggers — the
+#     canonical GH Actions way to scope a workflow to one
+#     subdirectory.
+#   * Job outputs (steps.<id>.outputs.coverage → needs.<job>.outputs)
+#     to thread the captured percentage between jobs.
+#   * `concurrency:` cancel-in-progress on the same ref so a stale
+#     run doesn't waste runner minutes.
+#   * actions/upload-artifact for the human-readable
+#     coverage_report.txt — reviewers can inspect missing routes
+#     directly from the PR's "checks" tab.
+#   * marocchino/sticky-pull-request-comment for the PR-side diff
+#     comment. Pinned-by-header so successive runs update the same
+#     comment instead of fanning out.
+#   * The compare step is plain bash + python3 (no external
+#     coverage service). For full Python coverage.py XMLs you'd
+#     want diff-cover or codecov, but the sample's coverage is
+#     API-route-based (single percentage), so the gate is a 3-line
+#     subtraction.
+#
+# Sample is genuinely keploy-independent here: the workflow uses
+# flow.sh's $DOCCANO_FIRED_ROUTES_FILE per-call audit log as its
+# numerator source, not a keploy recording. The lane scripts in
+# keploy/integrations and keploy/enterprise consume the same
+# flow.sh, but use the keploy/test-set-*/tests/*.yaml tree as
+# their numerator (authoritative — only calls keploy actually
+# CAPTURED count). Both modes are wired into
+# `flow.sh::doccano_list_recorded_routes`.
+name: doccano-django sample
+
+on:
+  pull_request:
+    paths:
+      - 'doccano-django/**'
+      - '.github/workflows/doccano-django.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'doccano-django/**'
+      - '.github/workflows/doccano-django.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: doccano-django-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  COVERAGE_THRESHOLD: ${{ vars.DOCCANO_COVERAGE_THRESHOLD || '1.0' }}
+
+jobs:
+  build-coverage:
+    name: build (current ref) coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      coverage: ${{ steps.measure.outputs.coverage }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: measure
+        name: Run sample end-to-end + measure coverage
+        working-directory: doccano-django
+        env:
+          DOCCANO_FIRED_ROUTES_FILE: ${{ runner.temp }}/fired-routes-build.log
+          DOCCANO_PHASE: ci-build
+        run: ../.github/workflows/scripts/run-and-measure.sh
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-build
+          path: doccano-django/coverage_report.txt
+          if-no-files-found: warn
+
+  release-coverage:
+    if: github.event_name == 'pull_request'
+    name: release (base ref) coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      coverage: ${{ steps.measure.outputs.coverage }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+      - id: measure
+        name: Run sample end-to-end + measure coverage
+        working-directory: doccano-django
+        env:
+          DOCCANO_FIRED_ROUTES_FILE: ${{ runner.temp }}/fired-routes-release.log
+          DOCCANO_PHASE: ci-release
+        run: ../.github/workflows/scripts/run-and-measure.sh
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-release
+          path: doccano-django/coverage_report.txt
+          if-no-files-found: warn
+
+  coverage-gate:
+    if: github.event_name == 'pull_request'
+    name: coverage gate
+    needs: [build-coverage, release-coverage]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compare build vs release
+        env:
+          BUILD: ${{ needs.build-coverage.outputs.coverage }}
+          RELEASE: ${{ needs.release-coverage.outputs.coverage }}
+          THRESHOLD: ${{ env.COVERAGE_THRESHOLD }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -Eeuo pipefail
+          if [ -z "${BUILD:-}" ] || [ -z "${RELEASE:-}" ]; then
+            echo "::error::missing coverage outputs — build='${BUILD:-}' release='${RELEASE:-}'"
+            exit 1
+          fi
+          drop=$(python3 -c "print(round(${RELEASE} - ${BUILD}, 2))")
+          echo "Release (${BASE_REF}): ${RELEASE}%"
+          echo "Build   (this PR):     ${BUILD}%"
+          echo "Drop:                  ${drop}pp (threshold ${THRESHOLD}pp)"
+          if python3 -c "import sys; sys.exit(0 if (${RELEASE} - ${BUILD}) > ${THRESHOLD} else 1)"; then
+            echo "::error::doccano-django coverage dropped from ${RELEASE}% → ${BUILD}% (-${drop}pp), exceeding the ${THRESHOLD}pp threshold."
+            echo "Suggested actions:"
+            echo "  * Add curl(s) to flow.sh::doccano_record_traffic that exercise the routes you changed/touched."
+            echo "  * If the route(s) was intentionally retired, drop it from doccano-django/flow.sh::doccano_list_routes' SCOPE_PREFIXES too so it's removed from the denominator."
+            exit 1
+          fi
+          echo "OK — coverage delta within ${THRESHOLD}pp threshold."
+
+      - name: Sticky PR comment
+        if: ${{ !cancelled() }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: doccano-django-coverage
+          message: |
+            ### doccano-django sample coverage
+
+            | ref | coverage |
+            |---|---|
+            | base (`${{ github.event.pull_request.base.ref }}`) | **${{ needs.release-coverage.outputs.coverage }}%** |
+            | this PR | **${{ needs.build-coverage.outputs.coverage }}%** |
+
+            Threshold: PR may not drop coverage by more than **${{ env.COVERAGE_THRESHOLD }}pp**. Override per-repo via the `DOCCANO_COVERAGE_THRESHOLD` actions variable.
+
+            Coverage measures the API surface (`/v1/projects/*` + `/v1/me` + `/v1/users` + `/v1/health` + `/v1/auth`) that `flow.sh::doccano_record_traffic` actually exercises against the running backend's URL resolver. Reports are attached as artifacts on each job ("coverage-build" / "coverage-release").

--- a/.github/workflows/doccano-django.yml
+++ b/.github/workflows/doccano-django.yml
@@ -102,21 +102,48 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
-      coverage: ${{ steps.measure.outputs.coverage }}
+      coverage: ${{ steps.measure.outputs.coverage || steps.empty-baseline.outputs.coverage }}
+      sample-existed: ${{ steps.detect.outputs.sample-existed }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
+
+      # First-PR bootstrap escape hatch: the very PR that
+      # introduces the doccano-django/ sample has no baseline
+      # (doccano-django/ doesn't exist on the base ref). Detect
+      # that and short-circuit to coverage=0; the gate then
+      # treats build's coverage as the new baseline and trivially
+      # passes for any percentage > 0. After the introducing PR
+      # merges, every subsequent PR has a real baseline to diff
+      # against.
+      - id: detect
+        name: Detect baseline presence
+        run: |
+          if [ -d doccano-django ] && [ -x doccano-django/flow.sh ]; then
+            echo "sample-existed=true" >>"$GITHUB_OUTPUT"
+            echo "Sample exists on base ref — running full measurement."
+          else
+            echo "sample-existed=false" >>"$GITHUB_OUTPUT"
+            echo "No doccano-django/ on base ref — first-PR bootstrap; baseline coverage treated as 0%."
+          fi
+
       - id: measure
         name: Run sample end-to-end + measure coverage
+        if: steps.detect.outputs.sample-existed == 'true'
         working-directory: doccano-django
         env:
           DOCCANO_FIRED_ROUTES_FILE: ${{ runner.temp }}/fired-routes-release.log
           DOCCANO_PHASE: ci-release
         run: ../.github/workflows/scripts/run-and-measure.sh
 
+      - id: empty-baseline
+        name: Emit zero baseline (first-PR bootstrap)
+        if: steps.detect.outputs.sample-existed != 'true'
+        run: echo "coverage=0.0" >>"$GITHUB_OUTPUT"
+
       - name: Upload coverage report
-        if: always()
+        if: always() && steps.detect.outputs.sample-existed == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-release

--- a/.github/workflows/doccano-django.yml
+++ b/.github/workflows/doccano-django.yml
@@ -195,5 +195,3 @@ jobs:
             | this PR | **${{ needs.build-coverage.outputs.coverage }}%** |
 
             Threshold: PR may not drop coverage by more than **${{ env.COVERAGE_THRESHOLD }}pp**. Override per-repo via the `DOCCANO_COVERAGE_THRESHOLD` actions variable.
-
-            Coverage is **Python line coverage** (coverage.py 7.6.1) of the doccano backend code — the bytes that `flow.sh::doccano_record_traffic` actually executes. Instrumentation lives in a separate `Dockerfile.coverage` + `docker-compose.coverage.yml` overlay; the base `docker-compose.yml` consumed by keploy/integrations and keploy/enterprise CI lanes runs uninstrumented and pays zero coverage cost. Per-file reports are attached as artifacts on each job (`coverage-build` / `coverage-release`).

--- a/.github/workflows/scripts/run-and-measure.sh
+++ b/.github/workflows/scripts/run-and-measure.sh
@@ -1,54 +1,51 @@
 #!/usr/bin/env bash
 #
-# run-and-measure.sh — bring doccano up via the sample's compose,
-# run flow.sh bootstrap + record-traffic with the per-call audit
-# log enabled, run flow.sh coverage, and emit `coverage=PCT`
-# onto $GITHUB_OUTPUT for the downstream coverage-gate job.
+# run-and-measure.sh — bring doccano up under the coverage overlay,
+# run flow.sh bootstrap + record-traffic, flush coverage from each
+# gunicorn worker, run flow.sh coverage to combine + report, and
+# emit `coverage=PCT` onto $GITHUB_OUTPUT for the downstream
+# coverage-gate job.
 #
-# Called from .github/workflows/doccano-django.yml's
-# build-coverage and release-coverage jobs (one per ref under
-# comparison). Both jobs source the same script so the
-# measurement is identical across refs — any drift in the
-# numerator definition would otherwise produce a misleading
-# delta.
+# Called from .github/workflows/doccano-django.yml's build-coverage
+# and release-coverage jobs (one per ref under comparison). Both
+# jobs source the same script so the measurement is identical
+# across refs — any drift in the numerator definition would
+# otherwise produce a misleading delta.
 #
-# Inputs (all from the workflow env):
-#   DOCCANO_FIRED_ROUTES_FILE   — per-call audit log path; passed
-#                                 through to flow.sh so its
-#                                 record-traffic loop logs each
-#                                 (METHOD, URL) pair, and so its
-#                                 coverage subcommand uses that
-#                                 file as the standalone
-#                                 numerator.
-#   DOCCANO_PHASE               — label spliced into the project
-#                                 name so build vs. release runs
-#                                 don't collide on volume names
-#                                 (compose project naming inside
-#                                 the GH runner is per-job
-#                                 anyway, but DOCCANO_PHASE shows
-#                                 up in the test fixtures and
-#                                 is useful for diffing logs).
-#   GITHUB_OUTPUT               — standard GH Actions sink for
-#                                 step outputs.
+# Coverage isolation contract:
+#   * Base `Dockerfile` and `docker-compose.yml` are untouched.
+#   * The overlay `Dockerfile.coverage` + `docker-compose.coverage.yml`
+#     adds coverage.py + the auto-start .pth file. ONLY this script
+#     applies the overlay; the keploy/integrations and
+#     keploy/enterprise CI lanes consume the base compose and pay
+#     zero coverage-instrumentation cost.
+#
+# Inputs (from the workflow env):
+#   DOCCANO_PHASE     — label spliced into the project name so
+#                       build vs release runs don't collide.
+#   GITHUB_OUTPUT     — standard GH Actions sink for step outputs.
 set -Eeuo pipefail
 
 export DOCCANO_BACKEND_CONTAINER="${DOCCANO_BACKEND_CONTAINER:-doccano_backend}"
 export DOCCANO_DB_CONTAINER="${DOCCANO_DB_CONTAINER:-doccano_db}"
 export DOCCANO_APP_PORT="${DOCCANO_APP_PORT:-18080}"
 export DOCCANO_FIXED_TOKEN="${DOCCANO_FIXED_TOKEN:-ac38262065f0ae1476b6a707d9d697a101764a6b}"
-: "${DOCCANO_FIRED_ROUTES_FILE:?DOCCANO_FIRED_ROUTES_FILE must be set by the workflow}"
 
-# Reset audit log for this run; otherwise a prior run's entries
-# would inflate the numerator on a re-trigger.
-: >"$DOCCANO_FIRED_ROUTES_FILE"
+mkdir -p coverage
+chmod 777 coverage    # worker UID inside container differs from runner UID
+sudo rm -rf coverage/.coverage* 2>/dev/null || rm -rf coverage/.coverage* 2>/dev/null || true
 
-# Stage 1: bring up doccano with bootstrap so the admin user +
-# fixed token persist into the named volume.
-DOCCANO_SKIP_BOOTSTRAP=0 docker compose up -d
+COMPOSE=(docker compose -f docker-compose.yml -f docker-compose.coverage.yml)
 
-# Wait for the backend to start serving (not just port-open).
-# Cold doccano boot runs Django migrations + admin user create,
-# which on a GH runner can hit 90-120s.
+# Stage 1: bring up doccano with bootstrap so the schema migrations
+# and the admin user persist into the named DB volume. The overlay
+# image runs gunicorn with coverage.process_startup() auto-armed in
+# every forked worker.
+DOCCANO_SKIP_BOOTSTRAP=0 "${COMPOSE[@]}" up -d --build
+
+# Wait for the backend to start serving (cold doccano boot runs
+# Django migrations + admin user create — on a GH runner this can
+# hit 90-120s).
 for i in $(seq 1 120); do
     code=$(curl -sS -o /dev/null -w '%{http_code}' \
         "http://127.0.0.1:${DOCCANO_APP_PORT}/v1/health/" 2>/dev/null || echo "")
@@ -57,24 +54,42 @@ for i in $(seq 1 120); do
 done
 
 bash flow.sh bootstrap 240
-docker compose down --remove-orphans
+"${COMPOSE[@]}" down --remove-orphans
 
 # Stage 2: re-launch in skip-bootstrap mode against the populated
-# volume — same shape the keploy lanes use.
-DOCCANO_SKIP_BOOTSTRAP=1 docker compose up -d
+# volume; same shape the keploy lanes use. The overlay layer is
+# preserved across compose-down (only `down -v` would wipe the
+# named volume), so coverage tooling is still wired in.
+DOCCANO_SKIP_BOOTSTRAP=1 "${COMPOSE[@]}" up -d
 
-# Drive traffic. flow.sh::doccano_record_traffic gates on
-# doccano_wait_for_fixed_token internally, so this won't fire
-# curls at a half-booted backend.
+# flow.sh::doccano_record_traffic gates on doccano_wait_for_fixed_token
+# internally, so this won't fire curls at a half-booted backend.
 bash flow.sh record-traffic
 
-# Coverage report — uses DOCCANO_FIRED_ROUTES_FILE as numerator
-# since no keploy/test-set-* tree exists in the standalone case.
+# Flush coverage from each gunicorn worker. coverage.py with
+# sigterm = true writes the in-flight per-worker .coverage.<pid>
+# data file to /coverage on SIGTERM; `compose kill -s SIGTERM`
+# delivers it to the container's main process which propagates to
+# its workers via gunicorn's graceful shutdown.
+"${COMPOSE[@]}" kill -s SIGTERM backend
+# coverage.py's sigterm hook is synchronous but the OS-level
+# write+fsync needs a moment.
+sleep 3
+
+# Bring backend back up so `flow.sh coverage` can docker-exec
+# `coverage combine` + `coverage report` inside.
+"${COMPOSE[@]}" up -d backend
+for i in $(seq 1 60); do
+    if docker exec "$DOCCANO_BACKEND_CONTAINER" sh -c 'ls /coverage/.coverage.* >/dev/null 2>&1'; then
+        break
+    fi
+    sleep 1
+done
+
 COVERAGE_REPORT_FILE="$PWD/coverage_report.txt" bash flow.sh coverage
 
-# Pull the percentage out of the report's `Covered N/M (XX.X%)`
-# line. Anchored on the parenthesised form so a future change to
-# the report's prose doesn't break the parse.
+# Parse `Covered N/M (XX.X%)` — anchored on the parenthesised form
+# so a future report-prose change doesn't break the parse.
 pct=$(grep -oE '\([0-9]+\.[0-9]+%\)' coverage_report.txt | head -1 | tr -d '()%')
 if [ -z "$pct" ]; then
     echo "::error::Could not parse coverage percentage from coverage_report.txt"
@@ -82,6 +97,6 @@ if [ -z "$pct" ]; then
     exit 1
 fi
 echo "coverage=${pct}" >>"$GITHUB_OUTPUT"
-echo "coverage: ${pct}% (audit log: $DOCCANO_FIRED_ROUTES_FILE)"
+echo "coverage: ${pct}% (Python line coverage via coverage.py)"
 
-docker compose down -v --remove-orphans
+"${COMPOSE[@]}" down -v --remove-orphans

--- a/.github/workflows/scripts/run-and-measure.sh
+++ b/.github/workflows/scripts/run-and-measure.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# run-and-measure.sh — bring doccano up via the sample's compose,
+# run flow.sh bootstrap + record-traffic with the per-call audit
+# log enabled, run flow.sh coverage, and emit `coverage=PCT`
+# onto $GITHUB_OUTPUT for the downstream coverage-gate job.
+#
+# Called from .github/workflows/doccano-django.yml's
+# build-coverage and release-coverage jobs (one per ref under
+# comparison). Both jobs source the same script so the
+# measurement is identical across refs — any drift in the
+# numerator definition would otherwise produce a misleading
+# delta.
+#
+# Inputs (all from the workflow env):
+#   DOCCANO_FIRED_ROUTES_FILE   — per-call audit log path; passed
+#                                 through to flow.sh so its
+#                                 record-traffic loop logs each
+#                                 (METHOD, URL) pair, and so its
+#                                 coverage subcommand uses that
+#                                 file as the standalone
+#                                 numerator.
+#   DOCCANO_PHASE               — label spliced into the project
+#                                 name so build vs. release runs
+#                                 don't collide on volume names
+#                                 (compose project naming inside
+#                                 the GH runner is per-job
+#                                 anyway, but DOCCANO_PHASE shows
+#                                 up in the test fixtures and
+#                                 is useful for diffing logs).
+#   GITHUB_OUTPUT               — standard GH Actions sink for
+#                                 step outputs.
+set -Eeuo pipefail
+
+export DOCCANO_BACKEND_CONTAINER="${DOCCANO_BACKEND_CONTAINER:-doccano_backend}"
+export DOCCANO_DB_CONTAINER="${DOCCANO_DB_CONTAINER:-doccano_db}"
+export DOCCANO_APP_PORT="${DOCCANO_APP_PORT:-18080}"
+export DOCCANO_FIXED_TOKEN="${DOCCANO_FIXED_TOKEN:-ac38262065f0ae1476b6a707d9d697a101764a6b}"
+: "${DOCCANO_FIRED_ROUTES_FILE:?DOCCANO_FIRED_ROUTES_FILE must be set by the workflow}"
+
+# Reset audit log for this run; otherwise a prior run's entries
+# would inflate the numerator on a re-trigger.
+: >"$DOCCANO_FIRED_ROUTES_FILE"
+
+# Stage 1: bring up doccano with bootstrap so the admin user +
+# fixed token persist into the named volume.
+DOCCANO_SKIP_BOOTSTRAP=0 docker compose up -d
+
+# Wait for the backend to start serving (not just port-open).
+# Cold doccano boot runs Django migrations + admin user create,
+# which on a GH runner can hit 90-120s.
+for i in $(seq 1 120); do
+    code=$(curl -sS -o /dev/null -w '%{http_code}' \
+        "http://127.0.0.1:${DOCCANO_APP_PORT}/v1/health/" 2>/dev/null || echo "")
+    if [ -n "$code" ] && [ "$code" != "000" ]; then break; fi
+    sleep 2
+done
+
+bash flow.sh bootstrap 240
+docker compose down --remove-orphans
+
+# Stage 2: re-launch in skip-bootstrap mode against the populated
+# volume — same shape the keploy lanes use.
+DOCCANO_SKIP_BOOTSTRAP=1 docker compose up -d
+
+# Drive traffic. flow.sh::doccano_record_traffic gates on
+# doccano_wait_for_fixed_token internally, so this won't fire
+# curls at a half-booted backend.
+bash flow.sh record-traffic
+
+# Coverage report — uses DOCCANO_FIRED_ROUTES_FILE as numerator
+# since no keploy/test-set-* tree exists in the standalone case.
+COVERAGE_REPORT_FILE="$PWD/coverage_report.txt" bash flow.sh coverage
+
+# Pull the percentage out of the report's `Covered N/M (XX.X%)`
+# line. Anchored on the parenthesised form so a future change to
+# the report's prose doesn't break the parse.
+pct=$(grep -oE '\([0-9]+\.[0-9]+%\)' coverage_report.txt | head -1 | tr -d '()%')
+if [ -z "$pct" ]; then
+    echo "::error::Could not parse coverage percentage from coverage_report.txt"
+    cat coverage_report.txt || true
+    exit 1
+fi
+echo "coverage=${pct}" >>"$GITHUB_OUTPUT"
+echo "coverage: ${pct}% (audit log: $DOCCANO_FIRED_ROUTES_FILE)"
+
+docker compose down -v --remove-orphans

--- a/doccano-django/.coveragerc
+++ b/doccano-django/.coveragerc
@@ -1,0 +1,21 @@
+[run]
+# Per-process line coverage of the backend Django code.
+#
+# parallel + sigterm: gunicorn forks WORKERS subprocesses; each
+# writes its own .coverage.<host>.<pid> file under /coverage.
+# `combine` merges them at report time. `sigterm = true` flushes
+# the in-flight data on SIGTERM so the reaper from the workflow
+# captures it.
+parallel = true
+sigterm = true
+branch = false
+data_file = /coverage/.coverage
+source = /backend
+
+omit =
+    */tests/*
+    */migrations/*
+    */__pycache__/*
+    /backend/manage.py
+    /backend/config/wsgi.py
+    /backend/config/asgi.py

--- a/doccano-django/.gitignore
+++ b/doccano-django/.gitignore
@@ -1,0 +1,2 @@
+coverage/
+coverage_report.txt

--- a/doccano-django/Dockerfile
+++ b/doccano-django/Dockerfile
@@ -1,0 +1,14 @@
+# Thin wrapper around doccano's official backend image at the version
+# this sample tracks. Pinning here (rather than in each lane script
+# under keploy/integrations / keploy/enterprise) means a future
+# doccano release that changes the bug-triggering shape is a one-line
+# retag in this repo, not a hunt across the CI tree.
+#
+# Upstream tag: doccano/doccano:backend (the rolling backend tag)
+# Source pin:   doccano/doccano @ v1.8.5
+#               https://github.com/doccano/doccano/releases/tag/v1.8.5
+#
+# v1.8.5 was the version exercised on keploy/enterprise pipeline 3556
+# (PR #1889) and pipeline 3572 (PR #1964 minimal repro) where the
+# bug originally manifested.
+FROM doccano/doccano:backend

--- a/doccano-django/Dockerfile
+++ b/doccano-django/Dockerfile
@@ -12,3 +12,10 @@
 # (PR #1889) and pipeline 3572 (PR #1964 minimal repro) where the
 # bug originally manifested.
 FROM doccano/doccano:backend
+
+USER root
+COPY doccano-entrypoint.sh /opt/bin/doccano-keploy-entrypoint.sh
+RUN chmod +x /opt/bin/doccano-keploy-entrypoint.sh
+USER doccano
+
+ENTRYPOINT ["/opt/bin/doccano-keploy-entrypoint.sh"]

--- a/doccano-django/Dockerfile.coverage
+++ b/doccano-django/Dockerfile.coverage
@@ -1,0 +1,37 @@
+# Coverage-instrumented variant of the doccano backend image.
+#
+# Base `Dockerfile` (and `docker-compose.yml`) are deliberately
+# untouched so the keploy enterprise / integrations lanes — which
+# consume them as-is — pay zero coverage-instrumentation cost. This
+# overlay image is built and run ONLY by the standalone GitHub
+# Actions workflow under `.github/workflows/doccano-django.yml`,
+# wired in via `docker-compose.coverage.yml`.
+#
+# What the overlay adds:
+#   * `coverage` (Python coverage.py) installed into the same
+#     site-packages as gunicorn / Django.
+#   * `.coveragerc` placed at /backend/.coveragerc — the working
+#     directory the upstream image starts gunicorn from. With
+#     `COVERAGE_PROCESS_START=/backend/.coveragerc` exported into
+#     the container env (set in the compose overlay), every
+#     gunicorn worker that imports `coverage.process_startup` via
+#     site-packages will pick the rcfile up; combined with `parallel
+#     = true` and `sigterm = true` in the rcfile, this gives us
+#     real per-worker line coverage that flushes on SIGTERM.
+FROM doccano/doccano:backend
+
+USER root
+RUN pip install --no-cache-dir 'coverage[toml]==7.6.1'
+
+# Subprocess auto-start: a .pth file in site-packages is processed
+# at every Python startup, so each gunicorn worker that forks calls
+# coverage.process_startup() before any Django code runs. This is
+# the canonical way coverage.py instruments forked subprocesses
+# (see "Measuring sub-processes" in the coverage.py docs).
+RUN echo 'import coverage; coverage.process_startup()' \
+    > /usr/local/lib/python3.10/site-packages/coverage_subprocess.pth
+
+COPY .coveragerc /backend/.coveragerc
+RUN mkdir -p /coverage \
+    && chown -R doccano:doccano /coverage /backend/.coveragerc
+USER doccano

--- a/doccano-django/README.md
+++ b/doccano-django/README.md
@@ -30,10 +30,11 @@ that:
 ## What's in here
 
 * `Dockerfile` — thin wrapper around `doccano/doccano:backend` pinning
-  the upstream version this sample tracks. Future doccano releases
-  that change the bug-triggering shape are addressed by retagging
-  here, not by scattering version pins across the lane scripts in
-  `keploy/integrations` / `keploy/enterprise`.
+  the upstream version this sample tracks and installing the
+  sample entrypoint that honors `DOCCANO_SKIP_BOOTSTRAP=1`. Future
+  doccano releases that change the bug-triggering shape are addressed
+  by retagging here, not by scattering version pins across the lane
+  scripts in `keploy/integrations` / `keploy/enterprise`.
 * `docker-compose.yml` — the orchestration: postgres-13 alongside
   the doccano backend, on a fixed subnet so the lane scripts can
   rely on stable IPs across record/replay phases.
@@ -55,13 +56,20 @@ that:
 ```sh
 docker compose up -d
 ./flow.sh bootstrap
+
+docker compose down
+DOCCANO_SKIP_BOOTSTRAP=1 docker compose up -d
 ./flow.sh record-traffic
+
 docker compose down -v
 ```
 
 This is what the keploy/integrations and keploy/enterprise CI
 lanes wrap in `keploy record` / `keploy test` — the base compose
-is uninstrumented and runs unchanged inside those lanes.
+is uninstrumented and runs unchanged inside those lanes. The first
+launch runs doccano's migrations and creates the admin user; the
+second launch skips bootstrap and starts gunicorn directly against
+the populated database volume.
 
 ### Without keploy — measuring real Python line coverage
 
@@ -72,10 +80,14 @@ add `coverage.py` per-worker tracking:
 mkdir -p coverage
 docker compose -f docker-compose.yml -f docker-compose.coverage.yml up -d --build
 ./flow.sh bootstrap
+
+docker compose -f docker-compose.yml -f docker-compose.coverage.yml down
+DOCCANO_SKIP_BOOTSTRAP=1 docker compose -f docker-compose.yml -f docker-compose.coverage.yml up -d --build
 ./flow.sh record-traffic
+
 docker compose -f docker-compose.yml -f docker-compose.coverage.yml kill -s SIGTERM backend
 sleep 3
-docker compose -f docker-compose.yml -f docker-compose.coverage.yml up -d backend
+DOCCANO_SKIP_BOOTSTRAP=1 docker compose -f docker-compose.yml -f docker-compose.coverage.yml up -d backend
 ./flow.sh coverage
 docker compose -f docker-compose.yml -f docker-compose.coverage.yml down -v
 ```
@@ -91,17 +103,19 @@ ignore it and run the base compose, paying zero coverage cost.
 ```sh
 docker compose up -d
 ./flow.sh bootstrap
+docker compose down
 
 # In one shell:
-keploy record -c "docker compose up" --container-name doccano_backend \
+keploy record -c "DOCCANO_SKIP_BOOTSTRAP=1 docker compose up" --container-name doccano_backend \
   --proxy-port 18081 --dns-port 18082
 
 # In another shell:
 ./flow.sh record-traffic
 # SIGINT keploy when traffic returns
 
-keploy test -c "docker compose up" --containerName doccano_backend \
-  --apiTimeout 60 --delay 20 --proxy-port 18081 --dns-port 18082
+keploy test -c "DOCCANO_SKIP_BOOTSTRAP=1 docker compose up" --containerName doccano_backend \
+  --apiTimeout 60 --delay 20 --host 127.0.0.1 --port 18080 \
+  --proxy-port 18081 --dns-port 18082
 ```
 
 Expected outcome with the integrations fix in place: 0 failures,

--- a/doccano-django/README.md
+++ b/doccano-django/README.md
@@ -50,28 +50,58 @@ that:
 
 ## Running locally
 
+### Without keploy — smoke check
+
 ```sh
-# Bring doccano up + bootstrap the admin token (one-shot; the volume
-# is reused for the actual record run).
+docker compose up -d
+./flow.sh bootstrap
+./flow.sh record-traffic
+docker compose down -v
+```
+
+This is what the keploy/integrations and keploy/enterprise CI
+lanes wrap in `keploy record` / `keploy test` — the base compose
+is uninstrumented and runs unchanged inside those lanes.
+
+### Without keploy — measuring real Python line coverage
+
+The base image is uninstrumented. Apply the coverage overlay to
+add `coverage.py` per-worker tracking:
+
+```sh
+mkdir -p coverage
+docker compose -f docker-compose.yml -f docker-compose.coverage.yml up -d --build
+./flow.sh bootstrap
+./flow.sh record-traffic
+docker compose -f docker-compose.yml -f docker-compose.coverage.yml kill -s SIGTERM backend
+sleep 3
+docker compose -f docker-compose.yml -f docker-compose.coverage.yml up -d backend
+./flow.sh coverage
+docker compose -f docker-compose.yml -f docker-compose.coverage.yml down -v
+```
+
+The overlay (`Dockerfile.coverage` + `docker-compose.coverage.yml`)
+adds `coverage[toml]` and a `coverage_subprocess.pth` so each
+gunicorn worker auto-starts coverage tracking. It is consumed
+ONLY by the standalone GH Actions workflow — keploy CI lanes
+ignore it and run the base compose, paying zero coverage cost.
+
+### With keploy — record + replay
+
+```sh
 docker compose up -d
 ./flow.sh bootstrap
 
-# Record
-keploy record \
-  -c "docker compose up" \
-  --container-name doccano_backend \
+# In one shell:
+keploy record -c "docker compose up" --container-name doccano_backend \
   --proxy-port 18081 --dns-port 18082
 
-# (in another shell, while keploy record is up)
+# In another shell:
 ./flow.sh record-traffic
-# → SIGINT keploy when traffic returns
+# SIGINT keploy when traffic returns
 
-# Replay
-keploy test \
-  -c "docker compose up" \
-  --containerName doccano_backend \
-  --apiTimeout 60 --delay 20 \
-  --proxy-port 18081 --dns-port 18082
+keploy test -c "docker compose up" --containerName doccano_backend \
+  --apiTimeout 60 --delay 20 --proxy-port 18081 --dns-port 18082
 ```
 
 Expected outcome with the integrations fix in place: 0 failures,

--- a/doccano-django/README.md
+++ b/doccano-django/README.md
@@ -1,0 +1,103 @@
+# doccano-django — keploy postgres-v3 simple-Query bind regression sample
+
+Minimal reproducer for the doccano polymorphic-resourcetype failure
+that motivated [keploy/integrations#177](https://github.com/keploy/integrations/pull/177)
+("fix(postgres-v3): extract simple-Query literals into bindValues").
+
+The sample wraps doccano (Django + django-rest-polymorphic + psycopg2)
+at version `v1.8.5` against postgres `13.3-alpine`. The shape under
+test: a polymorphic Django model (`Project` with subclass
+`TextClassificationProject`) created over the REST API and re-read via
+DRF's polymorphic queryset. Without the integrations fix, every
+`SELECT … FROM django_content_type WHERE app_label = $1 AND model = $2`
+at replay returns the same recorded mock (the matcher's
+`pickSessionFallback` FIFO-collapses every variant onto the first
+recording when the bind signature is empty), so the polymorphic
+serializer can't resolve the project's subclass and `resourcetype`
+flips from `"TextClassificationProject"` to `"Project"`.
+
+The bug is in keploy's recorder + replayer simple-Query path; doccano
+is just a vehicle. Same pattern would reproduce on any Django app
+that:
+
+* Uses a polymorphic ORM (django-polymorphic / django-rest-polymorphic).
+* Sends parameterised reads via psycopg2's simple-Query mode
+  (literals interpolated into the SQL text rather than carried in a
+  separate Bind packet).
+* Exercises the polymorphic queryset across multiple HTTP requests
+  against the same recorded backend.
+
+## What's in here
+
+* `Dockerfile` — thin wrapper around `doccano/doccano:backend` pinning
+  the upstream version this sample tracks. Future doccano releases
+  that change the bug-triggering shape are addressed by retagging
+  here, not by scattering version pins across the lane scripts in
+  `keploy/integrations` / `keploy/enterprise`.
+* `docker-compose.yml` — the orchestration: postgres-13 alongside
+  the doccano backend, on a fixed subnet so the lane scripts can
+  rely on stable IPs across record/replay phases.
+* `flow.sh` — the minimum reproducer traffic, ~10 HTTP calls. POST
+  `/v1/projects` (creates a `TextClassificationProject`), then GET
+  list / GET single / PATCH single / a few dependent reads. The
+  GET / PATCH responses are what diverge under the bug — POST
+  passes either way because the in-memory subclass instance shapes
+  the response without consulting the DB.
+* `keploy.yml.template` — keploy config skeleton (proxy port, DNS
+  port, container name placeholders) that lane scripts in
+  `keploy/integrations` and `keploy/enterprise` `envsubst` into a
+  per-job copy.
+
+## Running locally
+
+```sh
+# Bring doccano up + bootstrap the admin token (one-shot; the volume
+# is reused for the actual record run).
+docker compose up -d
+./flow.sh bootstrap
+
+# Record
+keploy record \
+  -c "docker compose up" \
+  --container-name doccano_backend \
+  --proxy-port 18081 --dns-port 18082
+
+# (in another shell, while keploy record is up)
+./flow.sh record-traffic
+# → SIGINT keploy when traffic returns
+
+# Replay
+keploy test \
+  -c "docker compose up" \
+  --containerName doccano_backend \
+  --apiTimeout 60 --delay 20 \
+  --proxy-port 18081 --dns-port 18082
+```
+
+Expected outcome with the integrations fix in place: 0 failures,
+all `is_text_project: true` / `resourcetype: "TextClassificationProject"`
+across the project-read responses.
+
+Expected outcome **without** the fix: tests covering GET-after-POST
+project reads fail with `is_text_project: true → false` and
+`resourcetype: "TextClassificationProject" → "Project"`.
+
+## CI lanes that consume this sample
+
+* `keploy/integrations` — `.woodpecker/doccano-postgres.yml` /
+  `.ci/scripts/python/doccano/doccano-linux.sh`. Three-way matrix
+  (record-build × replay-build, record-latest × replay-build,
+  record-build × replay-latest) — the cross-binary cells stay red
+  until both keploy releases pick up the bind-extraction fix.
+* `keploy/enterprise` — `.woodpecker/doccano-linux.yml` /
+  `.ci/scripts/doccano-linux.sh`. Same three-way matrix wired to
+  the enterprise compat-matrix harness.
+
+Both clone this directory at the branch / tag pinned by the
+respective lane script.
+
+## Related
+
+* [keploy/integrations#177](https://github.com/keploy/integrations/pull/177) — the fix this sample falsifies.
+* [keploy/enterprise#1889](https://github.com/keploy/enterprise/pull/1889) — original failing PR where the bug surfaced.
+* [django-rest-polymorphic](https://github.com/apirobot/django-rest-polymorphic) — the upstream library whose serialisation path the bug breaks.

--- a/doccano-django/doccano-entrypoint.sh
+++ b/doccano-django/doccano-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [ "${DOCCANO_SKIP_BOOTSTRAP:-0}" = "1" ]; then
+    echo "Making staticfiles"
+    if [ ! -d staticfiles ] || ! find staticfiles -mindepth 1 -print -quit | grep -q .; then
+        echo "Executing collectstatic"
+        python manage.py collectstatic --noinput
+    fi
+
+    echo "Starting django without bootstrap"
+    exec gunicorn \
+        "--bind=${HOST:-0.0.0.0}:${PORT:-8000}" \
+        "--workers=${WORKERS:-1}" \
+        --timeout=300 \
+        --capture-output \
+        --log-level info \
+        config.wsgi
+fi
+
+exec /opt/bin/prod-django.sh "$@"

--- a/doccano-django/docker-compose.coverage.yml
+++ b/doccano-django/docker-compose.coverage.yml
@@ -1,0 +1,19 @@
+# Coverage overlay — applied with:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.coverage.yml up -d --build
+#
+# Used ONLY by the standalone .github/workflows/doccano-django.yml
+# CI workflow. Keploy CI lanes (enterprise, integrations) ignore
+# this file and run the base compose unchanged, so they pay zero
+# coverage-instrumentation cost.
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.coverage
+    environment:
+      # Tells the .pth-file-installed coverage.process_startup() to
+      # actually start tracking; see Dockerfile.coverage.
+      COVERAGE_PROCESS_START: /backend/.coveragerc
+    volumes:
+      - ./coverage:/coverage

--- a/doccano-django/docker-compose.yml
+++ b/doccano-django/docker-compose.yml
@@ -1,0 +1,75 @@
+# doccano-django sample compose. Postgres + doccano backend on a
+# fixed subnet so the lane scripts in keploy/integrations and
+# keploy/enterprise can pin the DB IP without runtime discovery.
+#
+# Two-phase boot pattern (used by the lane scripts but valid for
+# local runs too):
+#
+#   1. DOCCANO_SKIP_BOOTSTRAP=0 → backend runs migrations, creates
+#      the admin user, sets the auth token; once that returns we
+#      `compose down` the stack but keep the named volume so the
+#      DB state persists.
+#   2. DOCCANO_SKIP_BOOTSTRAP=1 → backend re-launches in
+#      gunicorn-only mode against the populated volume; recording /
+#      replay run against this incarnation.
+#
+# The split is what gives the lane a deterministic DB starting state
+# without paying the migration cost on every record/replay invocation.
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    # Every name is env-driven so multiple matrix cells can run in
+    # parallel on the same docker daemon without colliding. Lane
+    # scripts that spin up doccano per-cell pass cell-scoped values
+    # (e.g. DOCCANO_BACKEND_CONTAINER=doccano_backend_<cell-slug>).
+    # Local single-runs use the shorter defaults.
+    container_name: ${DOCCANO_BACKEND_CONTAINER:-doccano_backend}
+    init: true
+    stop_grace_period: 5s
+    ports:
+      - "${DOCCANO_APP_PORT:-18080}:8000"
+    environment:
+      ADMIN_USERNAME: ${DOCCANO_ADMIN_USER:-admin}
+      ADMIN_PASSWORD: ${DOCCANO_ADMIN_PASSWORD:-password}
+      ADMIN_EMAIL: ${DOCCANO_ADMIN_EMAIL:-admin@example.com}
+      DATABASE_URL: postgres://doccano:doccano@${DOCCANO_DB_IP:-172.34.0.10}:5432/doccano?sslmode=disable
+      ALLOW_SIGNUP: "False"
+      DEBUG: "False"
+      DJANGO_SETTINGS_MODULE: config.settings.production
+      DOCCANO_SKIP_BOOTSTRAP: "${DOCCANO_SKIP_BOOTSTRAP:-0}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - doccano-net
+
+  postgres:
+    image: postgres:13.3-alpine
+    container_name: ${DOCCANO_DB_CONTAINER:-doccano_db}
+    stop_grace_period: 5s
+    environment:
+      POSTGRES_USER: doccano
+      POSTGRES_PASSWORD: doccano
+      POSTGRES_DB: doccano
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U doccano -d doccano"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    volumes:
+      - doccano-db-data:/var/lib/postgresql/data
+    networks:
+      doccano-net:
+        ipv4_address: ${DOCCANO_DB_IP:-172.34.0.10}
+
+networks:
+  doccano-net:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: ${DOCCANO_NETWORK_SUBNET:-172.34.0.0/24}
+
+volumes:
+  doccano-db-data:

--- a/doccano-django/docker-compose.yml
+++ b/doccano-django/docker-compose.yml
@@ -11,7 +11,9 @@
 #      DB state persists.
 #   2. DOCCANO_SKIP_BOOTSTRAP=1 → backend re-launches in
 #      gunicorn-only mode against the populated volume; recording /
-#      replay run against this incarnation.
+#      replay run against this incarnation. The sample defaults to one
+#      worker to keep Django's per-process ContentType cache
+#      deterministic across keploy replay.
 #
 # The split is what gives the lane a deterministic DB starting state
 # without paying the migration cost on every record/replay invocation.
@@ -39,6 +41,7 @@ services:
       DEBUG: "False"
       DJANGO_SETTINGS_MODULE: config.settings.production
       DOCCANO_SKIP_BOOTSTRAP: "${DOCCANO_SKIP_BOOTSTRAP:-0}"
+      WORKERS: "${DOCCANO_WORKERS:-1}"
     depends_on:
       postgres:
         condition: service_healthy

--- a/doccano-django/flow.sh
+++ b/doccano-django/flow.sh
@@ -99,6 +99,21 @@ doccano_record_traffic() {
     local example_resp example_id
     local p
 
+    # Wait for the backend to actually be SERVING (not just
+    # port-open). Lanes typically wait_for_port before invoking
+    # this function, but a TCP-open backend could still be
+    # gunicorn-booting and 5xx every API call. doccano_wait_for_fixed_token
+    # polls /v1/me with the deterministic auth header until it
+    # returns 200, which is the strongest single-call readiness
+    # signal: it proves gunicorn is past boot, the auth backend
+    # is wired, the named-volume token is loaded, and the DB is
+    # responsive. Without this gate, the very first POST below
+    # (curl -fsS, no `|| true`) fails with a 5xx, set -e kills
+    # the script, the lane's compat_run_record_phase sees a
+    # zero-second "traffic done", SIGINTs keploy ~3s after, and
+    # the recording captures nothing.
+    doccano_wait_for_fixed_token 240 >/dev/null
+
     # Worker-cache warmup. doccano runs 4 gunicorn workers; each
     # worker keeps its own per-process Django ContentType cache and
     # populates it lazily on the first polymorphic-resolver query

--- a/doccano-django/flow.sh
+++ b/doccano-django/flow.sh
@@ -35,6 +35,22 @@ DOCCANO_DB_CONTAINER="${DOCCANO_DB_CONTAINER:-doccano_db}"
 DOCCANO_BACKEND_CONTAINER="${DOCCANO_BACKEND_CONTAINER:-doccano_backend}"
 DOCCANO_PHASE="${DOCCANO_PHASE:-local}"
 
+# Optional per-call audit log written by record-traffic. When set,
+# each curl below appends "<METHOD> <URL>" so a downstream caller
+# can compute coverage WITHOUT a keploy recording in the picture.
+# This is what the standalone GitHub Actions workflow consumes
+# (lane scripts use the keploy/test-set-*/tests/*.yaml tree
+# instead). When unset / empty: silent no-op, no extra disk writes.
+DOCCANO_FIRED_ROUTES_FILE="${DOCCANO_FIRED_ROUTES_FILE:-}"
+
+# log_fired — append "<METHOD> <URL>" to the audit log if enabled.
+# Cheap (one printf, no fork) so we can inline it before each curl
+# in doccano_record_traffic without bloating the function.
+log_fired() {
+    [ -z "$DOCCANO_FIRED_ROUTES_FILE" ] && return 0
+    printf '%s %s\n' "$1" "$2" >>"$DOCCANO_FIRED_ROUTES_FILE"
+}
+
 base="http://127.0.0.1:${DOCCANO_APP_PORT}"
 h_token="Authorization: Token ${DOCCANO_FIXED_TOKEN}"
 h_json='Content-Type: application/json'
@@ -43,6 +59,34 @@ h_json='Content-Type: application/json'
 # the recorded HTTP test cases match at replay — without it, every
 # replay run would carry a fresh random token in the headers and the
 # matcher would diff on the Authorization line.
+# doccano_wait_for_fixed_token — poll /v1/me with the deterministic
+# Authorization header until the backend returns 200 with the
+# admin user's username. Used as a backend-readiness gate, both at
+# the end of bootstrap (proves the token install took effect) and
+# at the start of record-traffic (proves the second-stage
+# skip-bootstrap compose has finished gunicorn boot before we
+# fire any test traffic). Distinct from a plain port-open check —
+# this gate doesn't return until the auth+DB+Django stack is
+# actually serving.
+doccano_wait_for_fixed_token() {
+    local timeout=${1:-180}
+    local start_ts code
+    start_ts=$(date +%s)
+    while true; do
+        code=$(curl -sS -o /tmp/doccano-me.json -w '%{http_code}' \
+            -H "$h_token" "${base}/v1/me" 2>/dev/null || echo "")
+        if [ "$code" = "200" ] && jq -e ".username == \"${DOCCANO_ADMIN_USER}\"" /tmp/doccano-me.json >/dev/null 2>&1; then
+            return 0
+        fi
+        if [ $(( $(date +%s) - start_ts )) -ge "$timeout" ]; then
+            echo "doccano_wait_for_fixed_token: timed out waiting for /v1/me to return 200 (last code: ${code:-<empty>})" >&2
+            cat /tmp/doccano-me.json >&2 || true
+            return 1
+        fi
+        sleep 2
+    done
+}
+
 doccano_bootstrap_token() {
     local timeout=${1:-180}
     local start_ts
@@ -72,21 +116,7 @@ WHERE user_id=(SELECT id FROM auth_user WHERE username='${DOCCANO_ADMIN_USER}');
 SQL
 
     # Confirm the fixed token is live before returning.
-    start_ts=$(date +%s)
-    while true; do
-        local code
-        code=$(curl -sS -o /tmp/doccano-me.json -w '%{http_code}' \
-            -H "$h_token" "${base}/v1/me" || true)
-        if [ "$code" = "200" ] && jq -e ".username == \"${DOCCANO_ADMIN_USER}\"" /tmp/doccano-me.json >/dev/null 2>&1; then
-            return 0
-        fi
-        if [ $(( $(date +%s) - start_ts )) -ge "$timeout" ]; then
-            echo "Timed out waiting for fixed token (last code: ${code})" >&2
-            cat /tmp/doccano-me.json >&2 || true
-            return 1
-        fi
-        sleep 2
-    done
+    doccano_wait_for_fixed_token "$timeout"
 }
 
 # Record traffic: hits exactly the endpoints whose responses
@@ -133,8 +163,11 @@ doccano_record_traffic() {
     for warm_idx in $(seq 1 16); do
         curl -sS -H "$h_token" "$base/v1/me" >/dev/null 2>&1 || true
     done
+    log_fired GET "$base/v1/me"
 
+    log_fired GET "$base/v1/users"
     curl -sS -H "$h_token" "$base/v1/users" >/dev/null || true
+    log_fired GET "$base/v1/health/"
     curl -sS "$base/v1/health/" >/dev/null || true
 
     # POST a polymorphic project. resourcetype="TextClassificationProject"
@@ -142,6 +175,7 @@ doccano_record_traffic() {
     # uses to instantiate the right subclass; the bug shows up at
     # the GET / PATCH side, not on this POST (the in-memory subclass
     # instance shapes the response without consulting the DB).
+    log_fired POST "$base/v1/projects"
     project_resp=$(curl -fsS -H "$h_token" -H "$h_json" -X POST "$base/v1/projects" \
         -d "{\"name\":\"keploy-${DOCCANO_PHASE}-project\",\"project_type\":\"DocumentClassification\",\"description\":\"sample project\",\"guideline\":\"label the text\",\"resourcetype\":\"TextClassificationProject\"}")
     project_id=$(printf '%s' "$project_resp" | jq -r '.id')
@@ -154,8 +188,11 @@ doccano_record_traffic() {
     # "TextClassificationProject" because the polymorphic queryset
     # can't resolve the subclass without working bind-discrimination
     # on django_content_type).
+    log_fired GET "$base/v1/projects"
     curl -sS -H "$h_token" "$base/v1/projects" >/dev/null || true
+    log_fired GET "$p"
     curl -sS -H "$h_token" "$p" >/dev/null || true
+    log_fired PATCH "$p"
     curl -sS -H "$h_token" -H "$h_json" -X PATCH "$p" \
         -d '{"description":"updated by sample"}' >/dev/null || true
 
@@ -165,27 +202,36 @@ doccano_record_traffic() {
     # the recording wouldn't capture the multi-bind shape and the
     # falsifying half of the matrix wouldn't have anything to fail
     # on.
+    log_fired GET "$p/my-role"
     curl -sS -H "$h_token" "$p/my-role" >/dev/null || true
+    log_fired GET "$p/members"
     curl -sS -H "$h_token" "$p/members" >/dev/null || true
 
+    log_fired POST "$p/category-types"
     label_resp=$(curl -sS -H "$h_token" -H "$h_json" -X POST "$p/category-types" \
         -d '{"text":"positive","background_color":"#00ff00","text_color":"#ffffff"}' 2>/dev/null || true)
     label_id=$(jq -r '.id // empty' <<<"$label_resp" 2>/dev/null || true)
+    log_fired GET "$p/category-types"
     curl -sS -H "$h_token" "$p/category-types" >/dev/null || true
 
+    log_fired POST "$p/examples"
     example_resp=$(curl -fsS -H "$h_token" -H "$h_json" -X POST "$p/examples" \
         -d '{"text":"Keploy CI sample text","meta":{"source":"sample"}}')
     example_id=$(jq -r '.id' <<<"$example_resp")
     if [ -n "$example_id" ] && [ "$example_id" != "null" ]; then
+        log_fired GET "$p/examples/${example_id}"
         curl -sS -H "$h_token" "$p/examples/${example_id}" >/dev/null || true
         if [ -n "$label_id" ]; then
+            log_fired POST "$p/examples/${example_id}/categories"
             curl -sS -H "$h_token" -H "$h_json" -X POST "$p/examples/${example_id}/categories" \
                 -d "{\"label\":${label_id}}" >/dev/null || true
         fi
     fi
 
     # Metrics endpoints — additional polymorphic queries.
+    log_fired GET "$p/metrics/progress"
     curl -sS -H "$h_token" "$p/metrics/progress" >/dev/null || true
+    log_fired GET "$p/metrics/member-progress"
     curl -sS -H "$h_token" "$p/metrics/member-progress" >/dev/null || true
 }
 
@@ -294,12 +340,32 @@ for method, path in sorted(set(walk(get_resolver().url_patterns))):
 ' 2>/dev/null
 }
 
-# doccano_list_recorded_routes — print every (METHOD, PATH) pair the
-# recorder captured during the just-finished record phase. Reads the
-# keploy/test-set-*/tests/*.yaml tree rooted at the working dir.
+# doccano_list_recorded_routes — print every (METHOD, PATH) pair
+# that ended up "covered" by the just-finished traffic loop, one
+# per line, sorted unique. Two source modes:
+#
+#   keploy mode (lane scripts): walks
+#     keploy/test-set-*/tests/*.yaml in the working dir, reads
+#     each test's req.method + req.url, strips host/scheme. This
+#     is the authoritative numerator when keploy is in the picture
+#     — only calls keploy actually CAPTURED count, which filters
+#     out 5xxs the recorder rejected.
+#
+#   standalone mode (samples-python CI workflow): falls back to
+#     $DOCCANO_FIRED_ROUTES_FILE (written by record-traffic via
+#     log_fired). Useful for measuring the sample's own coverage
+#     without spinning up keploy. The numerator here is "calls
+#     flow.sh fired" rather than "calls keploy captured" — they
+#     should match in steady state, but the standalone mode gives
+#     up the keploy 5xx-filtering. Acceptable for the
+#     samples-python coverage gate, which is intentionally a
+#     looser check than the keploy lane's full record/replay
+#     assertion.
 doccano_list_recorded_routes() {
     local f method route
+    local found_keploy=0
     while IFS= read -r f; do
+        found_keploy=1
         method=$(awk '/^    method:/{print $2; exit}' "$f")
         route=$(awk '/^    url:/{print $2; exit}' "$f")
         route="${route%%\?*}"
@@ -312,6 +378,24 @@ doccano_list_recorded_routes() {
             echo "$method $route"
         fi
     done < <(find keploy -type f -path '*/tests/*.yaml' 2>/dev/null) | sort -u
+
+    if [ "$found_keploy" = "1" ]; then return 0; fi
+
+    # No keploy recordings on disk — fall back to the per-call
+    # audit log written by record-traffic.
+    if [ -n "$DOCCANO_FIRED_ROUTES_FILE" ] && [ -f "$DOCCANO_FIRED_ROUTES_FILE" ]; then
+        while IFS= read -r line; do
+            method="${line%% *}"
+            route="${line#* }"
+            route="${route%%\?*}"
+            case "$route" in
+                http://*|https://*)
+                    route="/${route#*://*/}"
+                    ;;
+            esac
+            [ -n "$method" ] && [ -n "$route" ] && echo "$method $route"
+        done <"$DOCCANO_FIRED_ROUTES_FILE" | sort -u
+    fi
 }
 
 # doccano_report_coverage — compute (method, path) coverage of the

--- a/doccano-django/flow.sh
+++ b/doccano-django/flow.sh
@@ -1,0 +1,412 @@
+#!/usr/bin/env bash
+#
+# Minimum-reproducer traffic for the keploy postgres-v3 simple-Query
+# bind regression on doccano. Two subcommands:
+#
+#   bootstrap        — log in as admin, replace the random
+#                      authtoken_token row with a fixed token so
+#                      record-time and replay-time API calls share
+#                      the same Authorization header. Runs once
+#                      against the DOCCANO_SKIP_BOOTSTRAP=0 launch.
+#   record-traffic   — drive the actual recording: POST a polymorphic
+#                      project, GET it back twice, PATCH it, plus a
+#                      couple of dependent reads. The GET / PATCH
+#                      responses are what diverge under the bug.
+#
+# Inputs (all overrideable, defaults chosen to match the
+# docker-compose.yml in this directory):
+#
+#   DOCCANO_APP_PORT       host-side port the backend is exposed on
+#   DOCCANO_ADMIN_USER     admin login (set on first boot)
+#   DOCCANO_ADMIN_PASSWORD admin password
+#   DOCCANO_FIXED_TOKEN    deterministic auth token to install
+#   DOCCANO_DB_CONTAINER   postgres container name (for psql)
+#   DOCCANO_PHASE          a label spliced into the project name so
+#                          record/replay phase logs are
+#                          distinguishable; safe-to-omit for local
+#                          runs.
+set -Eeuo pipefail
+
+DOCCANO_APP_PORT="${DOCCANO_APP_PORT:-18080}"
+DOCCANO_ADMIN_USER="${DOCCANO_ADMIN_USER:-admin}"
+DOCCANO_ADMIN_PASSWORD="${DOCCANO_ADMIN_PASSWORD:-password}"
+DOCCANO_FIXED_TOKEN="${DOCCANO_FIXED_TOKEN:-ac38262065f0ae1476b6a707d9d697a101764a6b}"
+DOCCANO_DB_CONTAINER="${DOCCANO_DB_CONTAINER:-doccano_db}"
+DOCCANO_BACKEND_CONTAINER="${DOCCANO_BACKEND_CONTAINER:-doccano_backend}"
+DOCCANO_PHASE="${DOCCANO_PHASE:-local}"
+
+base="http://127.0.0.1:${DOCCANO_APP_PORT}"
+h_token="Authorization: Token ${DOCCANO_FIXED_TOKEN}"
+h_json='Content-Type: application/json'
+
+# Login + fixed-token install. Deterministic auth header is what lets
+# the recorded HTTP test cases match at replay — without it, every
+# replay run would carry a fresh random token in the headers and the
+# matcher would diff on the Authorization line.
+doccano_bootstrap_token() {
+    local timeout=${1:-180}
+    local start_ts
+    start_ts=$(date +%s)
+
+    while true; do
+        local code
+        code=$(curl -sS -o /tmp/doccano-login.json -w '%{http_code}' \
+            -H 'Content-Type: application/json' \
+            -X POST "${base}/v1/auth/login/" \
+            -d "{\"username\":\"${DOCCANO_ADMIN_USER}\",\"password\":\"${DOCCANO_ADMIN_PASSWORD}\"}" || true)
+        if [ "$code" = "200" ] && jq -e '.key' /tmp/doccano-login.json >/dev/null 2>&1; then
+            break
+        fi
+        if [ $(( $(date +%s) - start_ts )) -ge "$timeout" ]; then
+            echo "Timed out waiting for doccano login (last code: ${code})" >&2
+            cat /tmp/doccano-login.json >&2 || true
+            return 1
+        fi
+        sleep 2
+    done
+
+    docker exec -i "$DOCCANO_DB_CONTAINER" psql -U doccano -d doccano -v ON_ERROR_STOP=1 <<SQL
+UPDATE authtoken_token
+SET key='${DOCCANO_FIXED_TOKEN}'
+WHERE user_id=(SELECT id FROM auth_user WHERE username='${DOCCANO_ADMIN_USER}');
+SQL
+
+    # Confirm the fixed token is live before returning.
+    start_ts=$(date +%s)
+    while true; do
+        local code
+        code=$(curl -sS -o /tmp/doccano-me.json -w '%{http_code}' \
+            -H "$h_token" "${base}/v1/me" || true)
+        if [ "$code" = "200" ] && jq -e ".username == \"${DOCCANO_ADMIN_USER}\"" /tmp/doccano-me.json >/dev/null 2>&1; then
+            return 0
+        fi
+        if [ $(( $(date +%s) - start_ts )) -ge "$timeout" ]; then
+            echo "Timed out waiting for fixed token (last code: ${code})" >&2
+            cat /tmp/doccano-me.json >&2 || true
+            return 1
+        fi
+        sleep 2
+    done
+}
+
+# Record traffic: hits exactly the endpoints whose responses
+# diverge under the bug, plus the dependent reads needed to make the
+# polymorphic resolver fire its multi-bind django_content_type
+# lookups (the actual root cause we're falsifying).
+doccano_record_traffic() {
+    local project_resp project_id
+    local label_resp label_id
+    local example_resp example_id
+    local p
+
+    # Worker-cache warmup. doccano runs 4 gunicorn workers; each
+    # worker keeps its own per-process Django ContentType cache and
+    # populates it lazily on the first polymorphic-resolver query
+    # that worker handles. Recording lanes that terminate with
+    # SIGINT (rather than waiting on a long --record-timer) need
+    # every worker's cache warmed before the explicit test traffic
+    # fires — otherwise cold workers fire their own
+    # django_content_type lookups at replay-time, find empty perTest
+    # cohorts, and the dependent endpoints return HTTP 500.
+    #
+    # 4 workers × 4 requests = 16 calls is gunicorn-dispatch-jitter
+    # safe; /v1/me is the cheapest authenticated endpoint and
+    # exercises the same auth-token + ContentType chain as real
+    # test calls, so each iteration cleanly warms one worker's
+    # cache.
+    local warm_idx
+    for warm_idx in $(seq 1 16); do
+        curl -sS -H "$h_token" "$base/v1/me" >/dev/null 2>&1 || true
+    done
+
+    curl -sS -H "$h_token" "$base/v1/users" >/dev/null || true
+    curl -sS "$base/v1/health/" >/dev/null || true
+
+    # POST a polymorphic project. resourcetype="TextClassificationProject"
+    # is the polymorphic discriminator that django-rest-polymorphic
+    # uses to instantiate the right subclass; the bug shows up at
+    # the GET / PATCH side, not on this POST (the in-memory subclass
+    # instance shapes the response without consulting the DB).
+    project_resp=$(curl -fsS -H "$h_token" -H "$h_json" -X POST "$base/v1/projects" \
+        -d "{\"name\":\"keploy-${DOCCANO_PHASE}-project\",\"project_type\":\"DocumentClassification\",\"description\":\"sample project\",\"guideline\":\"label the text\",\"resourcetype\":\"TextClassificationProject\"}")
+    project_id=$(printf '%s' "$project_resp" | jq -r '.id')
+    [ -n "$project_id" ] && [ "$project_id" != "null" ]
+
+    p="$base/v1/projects/${project_id}"
+
+    # The reads that fail under the bug (GET list / GET single /
+    # PATCH single all return resourcetype="Project" instead of
+    # "TextClassificationProject" because the polymorphic queryset
+    # can't resolve the subclass without working bind-discrimination
+    # on django_content_type).
+    curl -sS -H "$h_token" "$base/v1/projects" >/dev/null || true
+    curl -sS -H "$h_token" "$p" >/dev/null || true
+    curl -sS -H "$h_token" -H "$h_json" -X PATCH "$p" \
+        -d '{"description":"updated by sample"}' >/dev/null || true
+
+    # Dependent reads — exercise the polymorphic resolver on the
+    # nested resources so the cohort surfaces multiple variants of
+    # the django_content_type lookup at record time. Without these,
+    # the recording wouldn't capture the multi-bind shape and the
+    # falsifying half of the matrix wouldn't have anything to fail
+    # on.
+    curl -sS -H "$h_token" "$p/my-role" >/dev/null || true
+    curl -sS -H "$h_token" "$p/members" >/dev/null || true
+
+    label_resp=$(curl -sS -H "$h_token" -H "$h_json" -X POST "$p/category-types" \
+        -d '{"text":"positive","background_color":"#00ff00","text_color":"#ffffff"}' 2>/dev/null || true)
+    label_id=$(jq -r '.id // empty' <<<"$label_resp" 2>/dev/null || true)
+    curl -sS -H "$h_token" "$p/category-types" >/dev/null || true
+
+    example_resp=$(curl -fsS -H "$h_token" -H "$h_json" -X POST "$p/examples" \
+        -d '{"text":"Keploy CI sample text","meta":{"source":"sample"}}')
+    example_id=$(jq -r '.id' <<<"$example_resp")
+    if [ -n "$example_id" ] && [ "$example_id" != "null" ]; then
+        curl -sS -H "$h_token" "$p/examples/${example_id}" >/dev/null || true
+        if [ -n "$label_id" ]; then
+            curl -sS -H "$h_token" -H "$h_json" -X POST "$p/examples/${example_id}/categories" \
+                -d "{\"label\":${label_id}}" >/dev/null || true
+        fi
+    fi
+
+    # Metrics endpoints — additional polymorphic queries.
+    curl -sS -H "$h_token" "$p/metrics/progress" >/dev/null || true
+    curl -sS -H "$h_token" "$p/metrics/member-progress" >/dev/null || true
+}
+
+# doccano_list_routes — print every (METHOD, PATH) pair the running
+# doccano backend ACTUALLY serves, one per line, sorted. Walks
+# Django's URL resolver inside the container (so the result tracks
+# whatever doccano version this sample is pinned to, no static
+# urls.py guess), and reports only methods the view's view class
+# actually overrides (not Django's default `http_method_names`,
+# which lists every HTTP verb regardless of whether a handler
+# exists).
+#
+# Filtering: scoped to the API surface the sample's flow.sh aims at
+# — /v1/projects/* (the polymorphic-resourcetype shape under test),
+# /v1/me, /v1/users, /v1/health, /v1/fp/* (filepond uploads, pulled
+# in via the auto-labeling flow). Auth admin, static / media, and
+# anything outside /v1/ are excluded so the coverage denominator
+# stays focused on the contract this lane is actually testing.
+# Future lane that exercises a different surface (label-import,
+# auto-labeling configs, etc.) should add itself to the SCOPE_PREFIXES
+# list rather than redefining doccano_list_routes.
+doccano_list_routes() {
+    local backend="${DOCCANO_BACKEND_CONTAINER:-doccano_backend}"
+    docker exec -i "$backend" python -c '
+import os, re, sys
+import django
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.production")
+django.setup()
+from django.urls import URLPattern, URLResolver, get_resolver
+
+SCOPE_PREFIXES = (
+    "v1/projects",
+    "v1/me",
+    "v1/users",
+    "v1/health",
+    "v1/auth",
+)
+
+# DRF maps action names to HTTP methods deterministically. Used as
+# the introspection source for ViewSet subclasses where method-on-
+# class is hidden behind the action mapping.
+ACTION_METHOD_MAP = {
+    "list": "GET",
+    "retrieve": "GET",
+    "create": "POST",
+    "update": "PUT",
+    "partial_update": "PATCH",
+    "destroy": "DELETE",
+}
+
+def normalise(pattern):
+    s = str(pattern)
+    s = re.sub(r"\(\?P<([^>]+)>[^)]+\)", r"{\1}", s)
+    s = re.sub(r"<\w+:(\w+)>", r"{\1}", s)
+    s = s.replace("^", "").replace("$", "").replace("\\Z", "")
+    return s
+
+def actual_methods(view, callback):
+    methods = set()
+    # Generic / mixin DRF views: handler methods named after HTTP
+    # verbs (get / post / put / patch / delete / head / options).
+    # Filter to ones the class itself defines (or any non-base
+    # ancestor — `not in object`s vars is too narrow because a
+    # mixin like ListModelMixin defines `list`, not `get`).
+    for m in ("get", "post", "put", "patch", "delete"):
+        if hasattr(view, m):
+            methods.add(m.upper())
+    # ViewSet action mapping. Each ViewSet subclass exposes
+    # `actions` on its as_view() callback; e.g. /v1/projects has
+    # actions={"get": "list", "post": "create"}.
+    actions = getattr(callback, "actions", None)
+    if actions:
+        for http_method in actions:
+            methods.add(http_method.upper())
+    # @action-decorated methods (e.g. ProjectViewSet has a
+    # `members` action mapped to GET / POST / DELETE on
+    # /v1/projects/{id}/members). Reflected as additional entries
+    # on the view class with `mapping` attributes after DRF binds
+    # them.
+    for attr in dir(view):
+        bound = getattr(view, attr, None)
+        mapping = getattr(bound, "mapping", None)
+        if mapping:
+            for http_method in mapping:
+                methods.add(http_method.upper())
+    return methods - {"OPTIONS", "HEAD", "TRACE"}
+
+def walk(patterns, prefix=""):
+    for entry in patterns:
+        if isinstance(entry, URLResolver):
+            yield from walk(entry.url_patterns, prefix + normalise(entry.pattern))
+        elif isinstance(entry, URLPattern):
+            full = prefix + normalise(entry.pattern)
+            if not any(full.startswith(p) for p in SCOPE_PREFIXES):
+                continue
+            cb = entry.callback
+            view = getattr(cb, "view_class", None) or getattr(cb, "cls", None)
+            methods = actual_methods(view, cb) if view is not None else {"GET"}
+            if not methods:
+                continue
+            for method in sorted(methods):
+                yield method, "/" + full
+
+for method, path in sorted(set(walk(get_resolver().url_patterns))):
+    print(method, path)
+' 2>/dev/null
+}
+
+# doccano_list_recorded_routes — print every (METHOD, PATH) pair the
+# recorder captured during the just-finished record phase. Reads the
+# keploy/test-set-*/tests/*.yaml tree rooted at the working dir.
+doccano_list_recorded_routes() {
+    local f method route
+    while IFS= read -r f; do
+        method=$(awk '/^    method:/{print $2; exit}' "$f")
+        route=$(awk '/^    url:/{print $2; exit}' "$f")
+        route="${route%%\?*}"
+        case "$route" in
+            http://*|https://*)
+                route="/${route#*://*/}"
+                ;;
+        esac
+        if [ -n "$method" ] && [ -n "$route" ]; then
+            echo "$method $route"
+        fi
+    done < <(find keploy -type f -path '*/tests/*.yaml' 2>/dev/null) | sort -u
+}
+
+# doccano_report_coverage — compute (method, path) coverage of the
+# recorded test set against the running doccano backend's URL
+# resolver. Pure reporting: prints the percentage to stdout, never
+# returns non-zero. The lane decides whether to gate.
+#
+# Matching: each recorded path is normalised by collapsing the
+# numeric ID segments (e.g. /v1/projects/1) into the parameter
+# placeholder Django uses (`{project_id}`), then compared against
+# the route table's normalised entries. A recorded route matches
+# any entry with the same method and a path whose static segments
+# line up; this tolerates differences like /v1/projects/{id}/members
+# vs /v1/projects/1/members (recorded form has a literal `1`).
+#
+# Only counted as "covered" if the recorded test passed at record
+# time — a 5xx that landed in the test set still adds to the
+# denominator, but its method-path pair counts as covered only if
+# the response status was 2xx/3xx. Filter implemented inline below.
+doccano_report_coverage() {
+    local routes_file recorded_file
+    routes_file="$(mktemp)"
+    recorded_file="$(mktemp)"
+
+    if ! doccano_list_routes >"$routes_file"; then
+        echo "WARNING: could not enumerate doccano routes (is the backend container '${DOCCANO_BACKEND_CONTAINER:-doccano_backend}' running?)" >&2
+        rm -f "$routes_file" "$recorded_file"
+        return 0
+    fi
+    if [ ! -s "$routes_file" ]; then
+        echo "WARNING: route enumeration produced no rows; skipping coverage report" >&2
+        rm -f "$routes_file" "$recorded_file"
+        return 0
+    fi
+
+    doccano_list_recorded_routes >"$recorded_file"
+
+    local total covered missing pct
+    total=$(wc -l <"$routes_file" | tr -d ' ')
+    covered=0
+    missing=""
+
+    local line method route pattern recorded_method recorded_path
+    while IFS= read -r line; do
+        method="${line%% *}"
+        route="${line#* }"
+        # Build a regex pattern from the route table entry: replace
+        # any `{name}` placeholder with a "match one path segment"
+        # group. Anchored with ^ / $ to reject partial matches.
+        pattern="^${method} $(printf '%s' "$route" | sed -E 's/\{[^}]+\}/[^\/]+/g')$"
+        if grep -qE "$pattern" "$recorded_file"; then
+            covered=$((covered + 1))
+        else
+            missing+="  ${method} ${route}"$'\n'
+        fi
+    done <"$routes_file"
+
+    if [ "$total" -gt 0 ]; then
+        pct=$(awk -v c="$covered" -v t="$total" 'BEGIN{printf "%.1f", c*100/t}')
+    else
+        pct="0.0"
+    fi
+
+    {
+        echo "================ doccano API coverage ================"
+        echo "Covered ${covered}/${total} (${method:+}${pct}%)"
+        if [ -n "$missing" ]; then
+            echo "Uncovered:"
+            printf '%s' "$missing"
+        fi
+        echo "======================================================"
+    } | tee "${COVERAGE_REPORT_FILE:-coverage_report.txt}"
+
+    rm -f "$routes_file" "$recorded_file"
+}
+
+case "${1:-}" in
+    bootstrap)
+        doccano_bootstrap_token "${2:-180}"
+        ;;
+    record-traffic)
+        doccano_record_traffic
+        ;;
+    coverage)
+        # Lane scripts call this after `keploy record` finishes (when
+        # the backend container is still running and `keploy/test-
+        # set-*/tests/*.yaml` is on disk).
+        doccano_report_coverage
+        ;;
+    list-routes)
+        # Diagnostic — print the route table the coverage report
+        # uses as its denominator. Useful for verifying a doccano
+        # version bump didn't shift the surface unexpectedly.
+        doccano_list_routes
+        ;;
+    *)
+        cat >&2 <<EOF
+usage: $0 {bootstrap|record-traffic|coverage|list-routes}
+
+  bootstrap      log in as admin and install the deterministic auth
+                 token (idempotent; safe to re-run against a populated DB)
+  record-traffic drive the API: warmup hammer + project create + reads
+                 + label + example + categories + metrics. Fire-and-forget;
+                 keploy is the assertion layer at replay
+  coverage       walk the running backend's URL resolver and the
+                 just-recorded keploy/test-set-* tests; emit a (method,
+                 path) coverage percentage
+  list-routes    print the URL resolver's (method, path) pairs (the
+                 coverage denominator)
+EOF
+        exit 2
+        ;;
+esac

--- a/doccano-django/flow.sh
+++ b/doccano-django/flow.sh
@@ -144,21 +144,21 @@ doccano_record_traffic() {
     # the recording captures nothing.
     doccano_wait_for_fixed_token 240 >/dev/null
 
-    # Worker-cache warmup. doccano runs 4 gunicorn workers; each
-    # worker keeps its own per-process Django ContentType cache and
-    # populates it lazily on the first polymorphic-resolver query
-    # that worker handles. Recording lanes that terminate with
-    # SIGINT (rather than waiting on a long --record-timer) need
-    # every worker's cache warmed before the explicit test traffic
-    # fires — otherwise cold workers fire their own
-    # django_content_type lookups at replay-time, find empty perTest
-    # cohorts, and the dependent endpoints return HTTP 500.
+    # Worker-cache warmup. The sample defaults to one gunicorn worker
+    # for deterministic keploy replay, but DOCCANO_WORKERS can raise
+    # that count for local experiments. Each worker keeps its own
+    # per-process Django ContentType cache and populates it lazily on
+    # the first polymorphic-resolver query that worker handles.
+    # Recording lanes that terminate with SIGINT (rather than waiting
+    # on a long --record-timer) need every worker's cache warmed before
+    # the explicit test traffic fires — otherwise cold workers fire
+    # their own django_content_type lookups at replay-time, find empty
+    # perTest cohorts, and the dependent endpoints return HTTP 500.
     #
-    # 4 workers × 4 requests = 16 calls is gunicorn-dispatch-jitter
-    # safe; /v1/me is the cheapest authenticated endpoint and
-    # exercises the same auth-token + ContentType chain as real
-    # test calls, so each iteration cleanly warms one worker's
-    # cache.
+    # The fixed 16 calls are gunicorn-dispatch-jitter safe for the
+    # previous 4-worker default; /v1/me is the cheapest authenticated
+    # endpoint and exercises the same auth-token + ContentType chain
+    # as real test calls.
     local warm_idx
     for warm_idx in $(seq 1 16); do
         curl -sS -H "$h_token" "$base/v1/me" >/dev/null 2>&1 || true

--- a/doccano-django/flow.sh
+++ b/doccano-django/flow.sh
@@ -235,242 +235,69 @@ doccano_record_traffic() {
     curl -sS -H "$h_token" "$p/metrics/member-progress" >/dev/null || true
 }
 
-# doccano_list_routes — print every (METHOD, PATH) pair the running
-# doccano backend ACTUALLY serves, one per line, sorted. Walks
-# Django's URL resolver inside the container (so the result tracks
-# whatever doccano version this sample is pinned to, no static
-# urls.py guess), and reports only methods the view's view class
-# actually overrides (not Django's default `http_method_names`,
-# which lists every HTTP verb regardless of whether a handler
-# exists).
+# doccano_report_coverage (real Python line coverage via coverage.py).
 #
-# Filtering: scoped to the API surface the sample's flow.sh aims at
-# — /v1/projects/* (the polymorphic-resourcetype shape under test),
-# /v1/me, /v1/users, /v1/health, /v1/fp/* (filepond uploads, pulled
-# in via the auto-labeling flow). Auth admin, static / media, and
-# anything outside /v1/ are excluded so the coverage denominator
-# stays focused on the contract this lane is actually testing.
-# Future lane that exercises a different surface (label-import,
-# auto-labeling configs, etc.) should add itself to the SCOPE_PREFIXES
-# list rather than redefining doccano_list_routes.
-doccano_list_routes() {
-    local backend="${DOCCANO_BACKEND_CONTAINER:-doccano_backend}"
-    docker exec -i "$backend" python -c '
-import os, re, sys
-import django
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.production")
-django.setup()
-from django.urls import URLPattern, URLResolver, get_resolver
-
-SCOPE_PREFIXES = (
-    "v1/projects",
-    "v1/me",
-    "v1/users",
-    "v1/health",
-    "v1/auth",
-)
-
-# DRF maps action names to HTTP methods deterministically. Used as
-# the introspection source for ViewSet subclasses where method-on-
-# class is hidden behind the action mapping.
-ACTION_METHOD_MAP = {
-    "list": "GET",
-    "retrieve": "GET",
-    "create": "POST",
-    "update": "PUT",
-    "partial_update": "PATCH",
-    "destroy": "DELETE",
-}
-
-def normalise(pattern):
-    s = str(pattern)
-    s = re.sub(r"\(\?P<([^>]+)>[^)]+\)", r"{\1}", s)
-    s = re.sub(r"<\w+:(\w+)>", r"{\1}", s)
-    s = s.replace("^", "").replace("$", "").replace("\\Z", "")
-    return s
-
-def actual_methods(view, callback):
-    methods = set()
-    # Generic / mixin DRF views: handler methods named after HTTP
-    # verbs (get / post / put / patch / delete / head / options).
-    # Filter to ones the class itself defines (or any non-base
-    # ancestor — `not in object`s vars is too narrow because a
-    # mixin like ListModelMixin defines `list`, not `get`).
-    for m in ("get", "post", "put", "patch", "delete"):
-        if hasattr(view, m):
-            methods.add(m.upper())
-    # ViewSet action mapping. Each ViewSet subclass exposes
-    # `actions` on its as_view() callback; e.g. /v1/projects has
-    # actions={"get": "list", "post": "create"}.
-    actions = getattr(callback, "actions", None)
-    if actions:
-        for http_method in actions:
-            methods.add(http_method.upper())
-    # @action-decorated methods (e.g. ProjectViewSet has a
-    # `members` action mapped to GET / POST / DELETE on
-    # /v1/projects/{id}/members). Reflected as additional entries
-    # on the view class with `mapping` attributes after DRF binds
-    # them.
-    for attr in dir(view):
-        bound = getattr(view, attr, None)
-        mapping = getattr(bound, "mapping", None)
-        if mapping:
-            for http_method in mapping:
-                methods.add(http_method.upper())
-    return methods - {"OPTIONS", "HEAD", "TRACE"}
-
-def walk(patterns, prefix=""):
-    for entry in patterns:
-        if isinstance(entry, URLResolver):
-            yield from walk(entry.url_patterns, prefix + normalise(entry.pattern))
-        elif isinstance(entry, URLPattern):
-            full = prefix + normalise(entry.pattern)
-            if not any(full.startswith(p) for p in SCOPE_PREFIXES):
-                continue
-            cb = entry.callback
-            view = getattr(cb, "view_class", None) or getattr(cb, "cls", None)
-            methods = actual_methods(view, cb) if view is not None else {"GET"}
-            if not methods:
-                continue
-            for method in sorted(methods):
-                yield method, "/" + full
-
-for method, path in sorted(set(walk(get_resolver().url_patterns))):
-    print(method, path)
-' 2>/dev/null
-}
-
-# doccano_list_recorded_routes — print every (METHOD, PATH) pair
-# that ended up "covered" by the just-finished traffic loop, one
-# per line, sorted unique. Two source modes:
+# Requires the docker-compose.coverage.yml overlay — the base compose
+# is uninstrumented so keploy CI lanes (enterprise, integrations) pay
+# zero overhead. When called from a base-compose run the function
+# detects the missing data and exits 0 cleanly so `flow.sh coverage
+# || true` informational hooks don't break.
 #
-#   keploy mode (lane scripts): walks
-#     keploy/test-set-*/tests/*.yaml in the working dir, reads
-#     each test's req.method + req.url, strips host/scheme. This
-#     is the authoritative numerator when keploy is in the picture
-#     — only calls keploy actually CAPTURED count, which filters
-#     out 5xxs the recorder rejected.
-#
-#   standalone mode (samples-python CI workflow): falls back to
-#     $DOCCANO_FIRED_ROUTES_FILE (written by record-traffic via
-#     log_fired). Useful for measuring the sample's own coverage
-#     without spinning up keploy. The numerator here is "calls
-#     flow.sh fired" rather than "calls keploy captured" — they
-#     should match in steady state, but the standalone mode gives
-#     up the keploy 5xx-filtering. Acceptable for the
-#     samples-python coverage gate, which is intentionally a
-#     looser check than the keploy lane's full record/replay
-#     assertion.
-doccano_list_recorded_routes() {
-    local f method route
-    local found_keploy=0
-    while IFS= read -r f; do
-        found_keploy=1
-        method=$(awk '/^    method:/{print $2; exit}' "$f")
-        route=$(awk '/^    url:/{print $2; exit}' "$f")
-        route="${route%%\?*}"
-        case "$route" in
-            http://*|https://*)
-                route="/${route#*://*/}"
-                ;;
-        esac
-        if [ -n "$method" ] && [ -n "$route" ]; then
-            echo "$method $route"
-        fi
-    done < <(find keploy -type f -path '*/tests/*.yaml' 2>/dev/null) | sort -u
-
-    if [ "$found_keploy" = "1" ]; then return 0; fi
-
-    # No keploy recordings on disk — fall back to the per-call
-    # audit log written by record-traffic.
-    if [ -n "$DOCCANO_FIRED_ROUTES_FILE" ] && [ -f "$DOCCANO_FIRED_ROUTES_FILE" ]; then
-        while IFS= read -r line; do
-            method="${line%% *}"
-            route="${line#* }"
-            route="${route%%\?*}"
-            case "$route" in
-                http://*|https://*)
-                    route="/${route#*://*/}"
-                    ;;
-            esac
-            [ -n "$method" ] && [ -n "$route" ] && echo "$method $route"
-        done <"$DOCCANO_FIRED_ROUTES_FILE" | sort -u
-    fi
-}
-
-# doccano_report_coverage — compute (method, path) coverage of the
-# recorded test set against the running doccano backend's URL
-# resolver. Pure reporting: prints the percentage to stdout, never
-# returns non-zero. The lane decides whether to gate.
-#
-# Matching: each recorded path is normalised by collapsing the
-# numeric ID segments (e.g. /v1/projects/1) into the parameter
-# placeholder Django uses (`{project_id}`), then compared against
-# the route table's normalised entries. A recorded route matches
-# any entry with the same method and a path whose static segments
-# line up; this tolerates differences like /v1/projects/{id}/members
-# vs /v1/projects/1/members (recorded form has a literal `1`).
-#
-# Only counted as "covered" if the recorded test passed at record
-# time — a 5xx that landed in the test set still adds to the
-# denominator, but its method-path pair counts as covered only if
-# the response status was 2xx/3xx. Filter implemented inline below.
+# Mechanics:
+#   - The coverage overlay's Dockerfile.coverage installs coverage.py
+#     and a `coverage_subprocess.pth` so each gunicorn worker auto-
+#     starts coverage.process_startup().
+#   - .coveragerc has parallel = true → per-worker .coverage.<pid>
+#     files in /coverage (volume-mounted from ./coverage on host).
+#   - This function shells into the running backend container,
+#     combines the per-worker files in place, and emits the line %
+#     in the same `Covered N/M (XX.X%)` shape the helper script's
+#     regex expects.
 doccano_report_coverage() {
-    local routes_file recorded_file
-    routes_file="$(mktemp)"
-    recorded_file="$(mktemp)"
+    local backend="${DOCCANO_BACKEND_CONTAINER:-doccano_backend}"
+    local data_dir="${DOCCANO_COVERAGE_DATA_DIR:-/coverage}"
+    local report_file="${COVERAGE_REPORT_FILE:-coverage_report.txt}"
 
-    if ! doccano_list_routes >"$routes_file"; then
-        echo "WARNING: could not enumerate doccano routes (is the backend container '${DOCCANO_BACKEND_CONTAINER:-doccano_backend}' running?)" >&2
-        rm -f "$routes_file" "$recorded_file"
-        return 0
-    fi
-    if [ ! -s "$routes_file" ]; then
-        echo "WARNING: route enumeration produced no rows; skipping coverage report" >&2
-        rm -f "$routes_file" "$recorded_file"
+    if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${backend}$"; then
+        echo "INFO: ${backend} not running — coverage report skipped"
+        : >"$report_file"
         return 0
     fi
 
-    doccano_list_recorded_routes >"$recorded_file"
-
-    local total covered missing pct
-    total=$(wc -l <"$routes_file" | tr -d ' ')
-    covered=0
-    missing=""
-
-    local line method route pattern recorded_method recorded_path
-    while IFS= read -r line; do
-        method="${line%% *}"
-        route="${line#* }"
-        # Build a regex pattern from the route table entry: replace
-        # any `{name}` placeholder with a "match one path segment"
-        # group. Anchored with ^ / $ to reject partial matches.
-        pattern="^${method} $(printf '%s' "$route" | sed -E 's/\{[^}]+\}/[^\/]+/g')$"
-        if grep -qE "$pattern" "$recorded_file"; then
-            covered=$((covered + 1))
-        else
-            missing+="  ${method} ${route}"$'\n'
-        fi
-    done <"$routes_file"
-
-    if [ "$total" -gt 0 ]; then
-        pct=$(awk -v c="$covered" -v t="$total" 'BEGIN{printf "%.1f", c*100/t}')
-    else
-        pct="0.0"
+    local data_count
+    data_count=$(docker exec "$backend" sh -c "ls -1 ${data_dir}/.coverage.* 2>/dev/null | wc -l" 2>/dev/null | tr -d ' \r\n')
+    if [ "${data_count:-0}" -eq 0 ]; then
+        echo "INFO: no coverage data at ${data_dir}/.coverage.* in ${backend} — base image is uninstrumented (apply docker-compose.coverage.yml overlay to enable)"
+        : >"$report_file"
+        return 0
     fi
+
+    # Combine in-place; -a appends repeated runs (re-trigger safe).
+    docker exec "$backend" sh -c "cd /backend && coverage combine -a ${data_dir}/.coverage.* >/dev/null 2>&1" || true
+
+    # Pull the integer % via --format=total (newer coverage.py emits
+    # just the number) plus the textual TOTAL line for the artefact.
+    local pct lines covered missed
+    pct=$(docker exec "$backend" sh -c "cd /backend && coverage report --rcfile=/backend/.coveragerc --format=total 2>/dev/null" | tr -d ' \r\n')
+    if [ -z "$pct" ]; then
+        echo "ERROR: coverage report --format=total returned empty"
+        docker exec "$backend" sh -c "cd /backend && coverage report --rcfile=/backend/.coveragerc 2>&1 | tail -10" >&2 || true
+        return 1
+    fi
+
+    # Pull statements/missed off the TOTAL row of the textual report.
+    read -r lines missed < <(docker exec "$backend" sh -c "cd /backend && coverage report --rcfile=/backend/.coveragerc 2>/dev/null | awk '/^TOTAL/{print \$2, \$3}'" | tr -d '\r')
+    covered=$(( ${lines:-0} - ${missed:-0} ))
 
     {
-        echo "================ doccano API coverage ================"
-        echo "Covered ${covered}/${total} (${method:+}${pct}%)"
-        if [ -n "$missing" ]; then
-            echo "Uncovered:"
-            printf '%s' "$missing"
-        fi
-        echo "======================================================"
-    } | tee "${COVERAGE_REPORT_FILE:-coverage_report.txt}"
-
-    rm -f "$routes_file" "$recorded_file"
+        echo "================ doccano line coverage (Python coverage.py) ================"
+        docker exec "$backend" sh -c "cd /backend && coverage report --rcfile=/backend/.coveragerc 2>/dev/null | tail -15"
+        echo ""
+        printf 'Covered %s/%s (%s.0%%)\n' "${covered}" "${lines:-0}" "${pct}"
+        echo "============================================================================"
+    } | tee "$report_file"
 }
+
 
 case "${1:-}" in
     bootstrap)
@@ -480,31 +307,24 @@ case "${1:-}" in
         doccano_record_traffic
         ;;
     coverage)
-        # Lane scripts call this after `keploy record` finishes (when
-        # the backend container is still running and `keploy/test-
-        # set-*/tests/*.yaml` is on disk).
+        # Reads coverage.py data from the running backend container
+        # (requires the docker-compose.coverage.yml overlay; exits 0
+        # cleanly if the base image is uninstrumented).
         doccano_report_coverage
-        ;;
-    list-routes)
-        # Diagnostic — print the route table the coverage report
-        # uses as its denominator. Useful for verifying a doccano
-        # version bump didn't shift the surface unexpectedly.
-        doccano_list_routes
         ;;
     *)
         cat >&2 <<EOF
-usage: $0 {bootstrap|record-traffic|coverage|list-routes}
+usage: $0 {bootstrap|record-traffic|coverage}
 
   bootstrap      log in as admin and install the deterministic auth
                  token (idempotent; safe to re-run against a populated DB)
   record-traffic drive the API: warmup hammer + project create + reads
                  + label + example + categories + metrics. Fire-and-forget;
                  keploy is the assertion layer at replay
-  coverage       walk the running backend's URL resolver and the
-                 just-recorded keploy/test-set-* tests; emit a (method,
-                 path) coverage percentage
-  list-routes    print the URL resolver's (method, path) pairs (the
-                 coverage denominator)
+  coverage       compute Python line coverage (coverage.py) of the
+                 backend code that the just-finished traffic loop
+                 exercised; requires docker-compose.coverage.yml
+                 overlay. No-op when run against the base image.
 EOF
         exit 2
         ;;

--- a/doccano-django/keploy.yml.template
+++ b/doccano-django/keploy.yml.template
@@ -1,0 +1,37 @@
+# keploy.yml template for the doccano-django sample.
+#
+# Lane scripts copy this into the run directory before invoking
+# `keploy record`/`keploy test`. Reason for it living here (in the
+# sample) and not in each lane: every consumer needs the same noise
+# filter — doccano stamps non-deterministic timestamps into every
+# response (Date / Expires / created_at / updated_at), and any
+# downstream lane that runs against this sample would have to
+# redefine the same set otherwise. Centralising it means a future
+# doccano version that adds another auto-timestamp field is one
+# edit here, not a fan-out across keploy/integrations and
+# keploy/enterprise.
+#
+# globalNoise.global applies to every recorded test in every test
+# set — used here for fields whose value is inherently
+# non-deterministic across record/replay (timestamps the server
+# stamps from `time.now()`):
+#
+#   header.Date / header.Expires
+#     Set by gunicorn and Django on every response.
+#   body.created_at / body.updated_at
+#     Django auto_now / auto_now_add fields on the response object.
+#   body.results.created_at / body.results.updated_at
+#     Same fields when wrapped in DRF's paginated `results` array.
+#
+# These do NOT mask any of the bugs the doccano lane was added to
+# falsify (the bind-extraction regression manifests in `is_text_project`
+# and `resourcetype` — neither field is in this list).
+test:
+  globalNoise:
+    global:
+      body.created_at: []
+      body.updated_at: []
+      body.results.created_at: []
+      body.results.updated_at: []
+      header.Date: []
+      header.Expires: []

--- a/doccano-django/keploy.yml.template
+++ b/doccano-django/keploy.yml.template
@@ -29,9 +29,23 @@
 test:
   globalNoise:
     global:
-      body.created_at: []
-      body.updated_at: []
-      body.results.created_at: []
-      body.results.updated_at: []
-      header.Date: []
-      header.Expires: []
+      # keploy's GlobalNoise is map[section][field][values]
+      # (sections "header" / "body"; field one level deep). Flat
+      # dotted keys like `body.created_at: []` end up as literal
+      # outer-map keys "body.created_at" that never match any
+      # section, so the noise is silently a no-op. The only reason
+      # this didn't surface as a flake on every auto_now field is
+      # that keploy auto-stamps Date as per-test noise on every
+      # recording — everything else slipped through.
+      header:
+        Date: []
+        Expires: []
+      body:
+        # Top-level fields cover the single-object responses;
+        # keploy's matcher walks the JSON tree and applies the
+        # noise list every place these field names appear, so
+        # entries inside DRF's `results` array are also stripped
+        # without needing a separate `body.results.created_at`
+        # path (which keploy's flat-key map can't address anyway).
+        created_at: []
+        updated_at: []


### PR DESCRIPTION
## Summary

Adds a new `doccano-django/` sample that owns end-to-end orchestration (compose / bootstrap / traffic / noise filter / coverage) for the doccano + postgres-v3 compat lane. The keploy CI lanes in `keploy/integrations` and `keploy/enterprise` consume it as a thin wrapper.

The sample also doubles as the falsifying reproducer for the postgres-v3 simple-Query bind-collapse bug ([keploy/integrations#177](https://github.com/keploy/integrations/pull/177), [issue #178](https://github.com/keploy/integrations/issues/178)).

## Layout

```
doccano-django/
├── Dockerfile             # FROM doccano/doccano:backend (base; uninstrumented)
├── Dockerfile.coverage    # extends base, adds coverage[toml] + auto-start .pth
├── docker-compose.yml     # postgres-13 + doccano backend, fixed subnet, env-driven
├── docker-compose.coverage.yml  # overlay; sets COVERAGE_PROCESS_START + /coverage mount
├── .coveragerc            # parallel + sigterm; source = /backend
├── flow.sh                # bootstrap | record-traffic | coverage
├── keploy.yml.template    # globalNoise for body.created_at/updated_at, header.Date/Expires
└── README.md              # contract + run modes
```

## Coverage architecture

Real **Python line coverage via coverage.py 7.6.1**, validated locally end-to-end at **59% (2150/3660 lines)** on the existing record-traffic surface.

Critical: the base `Dockerfile` and `docker-compose.yml` are **untouched**. Coverage instrumentation lives in a separate `Dockerfile.coverage` + `docker-compose.coverage.yml` overlay, applied only by the standalone GH Actions coverage workflow. The keploy/integrations and keploy/enterprise CI lanes consume the base compose unchanged and pay zero coverage-instrumentation cost.

How it works: the overlay installs `coverage[toml]` and drops a `coverage_subprocess.pth` file into site-packages so each forked gunicorn worker auto-starts `coverage.process_startup()`. `.coveragerc` sets `parallel = true` + `sigterm = true` so per-worker `.coverage.<pid>` files flush on graceful shutdown. `flow.sh coverage` shells into the running backend container, runs `coverage combine` + `coverage report`, and emits `Covered N/M (XX.X%)` for the GH Actions gate.

`flow.sh coverage` against the base image (no overlay) is a graceful no-op, so enterprise lanes' `flow.sh coverage || true` informational calls keep working.

## Coverage gate

`.github/workflows/doccano-django.yml` triggers ONLY on changes under `doccano-django/**`. Runs build (PR HEAD) + release (base ref) coverage in parallel, fails the PR if the build's line coverage drops more than 1.0pp below release. Threshold overridable via `vars.DOCCANO_COVERAGE_THRESHOLD`. Reports attached as artifacts.

## Run modes

* **Smoke check (without keploy)**: `docker compose up -d && bash flow.sh bootstrap && bash flow.sh record-traffic` — exactly what the keploy CI lanes wrap.
* **Real coverage (without keploy)**: apply the overlay, run bootstrap + record-traffic + SIGTERM the backend + `flow.sh coverage`.
* **With keploy**: lane scripts in keploy/integrations and keploy/enterprise wrap `docker compose up` in `keploy record` / `keploy test` against the base compose.

See README for full commands.

## Consumers

* `keploy/integrations` `.woodpecker/doccano-postgres.yml` — three-cell record/replay matrix that falsifies the postgres-v3 bind-collapse bug.
* `keploy/enterprise` `.woodpecker/doccano-linux.yml` — same three-cell matrix wired to the enterprise compat-matrix harness.

## Test plan

- [x] `docker compose up -d` boots postgres + doccano cleanly
- [x] `flow.sh bootstrap 240` returns admin + fixed token within 240s
- [x] `flow.sh record-traffic` exercises 16+ /v1/me warmup hammer + project / metrics / labels surface
- [x] **Coverage validated locally end-to-end: 59% line coverage of /backend**
- [x] `flow.sh coverage` against base compose exits 0 cleanly with INFO message