### PR TITLE
chore: replace the slack url to updated invite url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <a href="CODE_OF_CONDUCT.md" alt="Contributions welcome">
     <img src="https://img.shields.io/badge/Contributions-Welcome-brightgreen?logo=github" /></a>
 
-  <a href="https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg" alt="Slack">
+  <a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA" alt="Slack">
     <img src=".github/slack.svg" /></a>
 
   <a href="https://opensource.org/licenses/Apache-2.0" alt="License">
@@ -33,7 +33,7 @@ This repo contains the samples for [Keploy's](https://keploy.io) integration wit
 
 Reach out to us. We're here to help!
 
-[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://join.slack.com/t/keploy/shared_invite/zt-357qqm9b5-PbZRVu3Yt2rJIa6ofrwWNg)
+[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
 [![LinkedIn](https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/keploy/)
 [![YouTube](https://img.shields.io/badge/YouTube-%23FF0000.svg?style=for-the-badge&logo=YouTube&logoColor=white)](https://www.youtube.com/channel/UC6OTg7F4o0WkmNtSoob34lg)
 [![Twitter](https://img.shields.io/badge/Twitter-%231DA1F2.svg?style=for-the-badge&logo=Twitter&logoColor=white)](https://twitter.com/Keployio)


### PR DESCRIPTION
## Summary

- Updated the Slack community invite URL in `README.md` from the expired link to the new active invite link.

## Changes

- `README.md`: Replaced old Slack invite URL (`zt-357qqm9b5-...`) with new URL (`zt-3zcnuqfgl-...`) in both the header badge link and the Community Support section badge.

## Notes

No code changes — documentation-only update. All other `slack.com` references in the repo are `hooks.slack.com` webhook URLs used by test fixtures in `flask-secret/`, which are unrelated and untouched.
