### PR TITLE
chore: replace the temp slack url to permanent route

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <a href="CODE_OF_CONDUCT.md" alt="Contributions welcome">
     <img src="https://img.shields.io/badge/Contributions-Welcome-brightgreen?logo=github" /></a>
 
-  <a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA" alt="Slack">
+  <a href="https://keploy.io/slack" alt="Slack">
     <img src=".github/slack.svg" /></a>
 
   <a href="https://opensource.org/licenses/Apache-2.0" alt="License">
@@ -33,7 +33,7 @@ This repo contains the samples for [Keploy's](https://keploy.io) integration wit
 
 Reach out to us. We're here to help!
 
-[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
+[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://keploy.io/slack)
 [![LinkedIn](https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/keploy/)
 [![YouTube](https://img.shields.io/badge/YouTube-%23FF0000.svg?style=for-the-badge&logo=YouTube&logoColor=white)](https://www.youtube.com/channel/UC6OTg7F4o0WkmNtSoob34lg)
 [![Twitter](https://img.shields.io/badge/Twitter-%231DA1F2.svg?style=for-the-badge&logo=Twitter&logoColor=white)](https://twitter.com/Keployio)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
   <a href="CODE_OF_CONDUCT.md" alt="Contributions welcome">
     <img src="https://img.shields.io/badge/Contributions-Welcome-brightgreen?logo=github" /></a>
 
-  <a href="https://keploy.io/slack" alt="Slack">
-    <img src=".github/slack.svg" /></a>
+  <a href="https://keploy.io/slack" aria-label="Slack">
+    <img src=".github/slack.svg" alt="Slack" /></a>
 
   <a href="https://opensource.org/licenses/Apache-2.0" alt="License">
     <img src=".github/License-Apache_2.0-blue.svg" /></a>


### PR DESCRIPTION
## Summary

- Replaces the temporary Slack invite URL (`join.slack.com/t/keploy/shared_invite/...`) with the permanent redirect `https://keploy.io/slack` in both badge locations in the root `README.md`.
- This is the second and final step after #103, which replaced the previous invite link with another temp one. The new URL is stable and won't need to be updated again when the invite link rotates.

## Changes

- `README.md` (line 7): Updated `<a href>` in the header badge
- `README.md` (line 36): Updated the community support Slack badge link

## Notes

- `flask-secret/` references to `hooks.slack.com` are intentionally untouched as they are part of the secret-generation sample app, not Keploy community links.
- Sub-directory READMEs do not contain any Slack invite URLs.
