### PR TITLE
fix: update download URLs from S3 to Azure

### DIFF
--- a/flask_mysql/Dockerfile
+++ b/flask_mysql/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install --no-cache-dir gunicorn
 
 # Create the keploy directory and download the time freeze agent
 RUN mkdir -p /lib/keploy
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/freeze_time_amd64.so /lib/keploy/freeze_time_amd64.so
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/freeze_time_amd64.so /lib/keploy/freeze_time_amd64.so
 RUN chmod +x /lib/keploy/freeze_time_amd64.so
 RUN ls -la /lib/keploy/freeze_time_amd64.so
 


### PR DESCRIPTION
Download hosting has moved from the keploy-enterprise S3 bucket to Azure (keployenterprise storage account), as the S3 bucket is being decommissioned. This updates the freeze_time library ADD URL in the flask_mysql Dockerfile. The new URL is verified serving (HTTP 206).